### PR TITLE
feat: brand consistency — teal palette across all 37 pages and components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,7 +1260,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/app/admin/email-status/page.tsx
+++ b/src/app/admin/email-status/page.tsx
@@ -65,7 +65,7 @@ export default function EmailStatusPage() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-brand-600 mx-auto mb-4"></div>
           <p className="text-gray-600">Loading email status...</p>
         </div>
       </div>
@@ -137,9 +137,9 @@ export default function EmailStatusPage() {
               <h2 className="text-xl font-semibold text-gray-900 mb-4">Email Sequences Overview</h2>
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-                <div className="bg-blue-50 p-4 rounded-lg">
-                  <div className="text-2xl font-bold text-blue-600">{status.sequencesCount}</div>
-                  <div className="text-sm text-blue-800">Active Sequences</div>
+                <div className="bg-brand-50 p-4 rounded-lg">
+                  <div className="text-2xl font-bold text-brand-600">{status.sequencesCount}</div>
+                  <div className="text-sm text-brand-800">Active Sequences</div>
                 </div>
                 <div className="bg-green-50 p-4 rounded-lg">
                   <div className="text-2xl font-bold text-green-600">
@@ -238,12 +238,12 @@ export default function EmailStatusPage() {
                   </ol>
                 </div>
 
-                <div className="p-4 bg-blue-50 border border-blue-200 rounded-md">
-                  <h3 className="text-sm font-medium text-blue-800 mb-2">Available Email Templates</h3>
-                  <p className="text-sm text-blue-700 mb-2">
+                <div className="p-4 bg-brand-50 border border-brand-200 rounded-md">
+                  <h3 className="text-sm font-medium text-brand-800 mb-2">Available Email Templates</h3>
+                  <p className="text-sm text-brand-700 mb-2">
                     These templates are ready to be configured once the database is set up:
                   </p>
-                  <ul className="text-sm text-blue-700 space-y-1">
+                  <ul className="text-sm text-brand-700 space-y-1">
                     <li>• <strong>Waitlist Welcome</strong> - Sent immediately when someone joins</li>
                     <li>• <strong>Calculator Follow-up</strong> - Sent 2h after using tax calculator</li>
                     <li>• <strong>AIMI Calculator Follow-up</strong> - Sent 1h after AIMI calculation</li>
@@ -282,7 +282,7 @@ export default function EmailStatusPage() {
           <div className="mt-6 text-center">
             <button
               onClick={fetchEmailStatus}
-              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-brand-600 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-600"
             >
               🔄 Refresh Status
             </button>

--- a/src/app/admin/survey-results/page.tsx
+++ b/src/app/admin/survey-results/page.tsx
@@ -73,7 +73,7 @@ export default function SurveyResultsPage() {
   const getWillingnessColor = (value: string) => {
     const colors = {
       'definitely': 'text-green-600 bg-green-50',
-      'probably': 'text-blue-600 bg-blue-50',
+      'probably': 'text-brand-600 bg-brand-50',
       'maybe': 'text-yellow-600 bg-yellow-50',
       'probably_not': 'text-orange-600 bg-orange-50',
       'definitely_not': 'text-red-600 bg-red-50'
@@ -106,7 +106,7 @@ export default function SurveyResultsPage() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-600 mx-auto mb-4"></div>
           <p className="text-gray-600">A carregar resultados do survey...</p>
         </div>
       </div>
@@ -138,7 +138,7 @@ export default function SurveyResultsPage() {
                 onClick={() => setActiveTab('overview')}
                 className={`py-2 px-1 border-b-2 font-medium text-sm ${
                   activeTab === 'overview'
-                    ? 'border-blue-500 text-blue-600'
+                    ? 'border-brand-500 text-brand-600'
                     : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
                 }`}
               >
@@ -148,7 +148,7 @@ export default function SurveyResultsPage() {
                 onClick={() => setActiveTab('responses')}
                 className={`py-2 px-1 border-b-2 font-medium text-sm ${
                   activeTab === 'responses'
-                    ? 'border-blue-500 text-blue-600'
+                    ? 'border-brand-500 text-brand-600'
                     : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
                 }`}
               >
@@ -184,7 +184,7 @@ export default function SurveyResultsPage() {
 
               <div className="bg-white rounded-lg shadow p-6">
                 <h3 className="text-sm font-medium text-gray-500">Preço Médio</h3>
-                <p className="text-3xl font-bold text-blue-600">
+                <p className="text-3xl font-bold text-brand-600">
                   €{stats.overview.avg_max_price?.toFixed(2) || '0'}
                 </p>
                 <p className="text-sm text-gray-600 mt-1">por mês</p>
@@ -219,7 +219,7 @@ export default function SurveyResultsPage() {
                         <div
                           className={`h-2 rounded-full ${
                             item.willingness_to_pay === 'definitely' ? 'bg-green-500' :
-                            item.willingness_to_pay === 'probably' ? 'bg-blue-500' :
+                            item.willingness_to_pay === 'probably' ? 'bg-brand-500' :
                             item.willingness_to_pay === 'maybe' ? 'bg-yellow-500' :
                             item.willingness_to_pay === 'probably_not' ? 'bg-orange-500' :
                             'bg-red-500'
@@ -245,8 +245,8 @@ export default function SurveyResultsPage() {
               <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-7 gap-4">
                 {stats.price_distribution.map((item) => (
                   <div key={item.price_range} className="text-center">
-                    <div className="bg-blue-100 rounded-lg p-4">
-                      <p className="text-2xl font-bold text-blue-600">{item.count}</p>
+                    <div className="bg-brand-100 rounded-lg p-4">
+                      <p className="text-2xl font-bold text-brand-600">{item.count}</p>
                       <p className="text-xs text-gray-600 mt-1">{item.price_range}</p>
                     </div>
                   </div>
@@ -280,7 +280,7 @@ export default function SurveyResultsPage() {
                     <h4 className="text-sm font-medium text-gray-900 mb-2">Funcionalidades Mais Valiosas</h4>
                     <div className="flex flex-wrap gap-1">
                       {response.most_valuable_features.map((feature, i) => (
-                        <span key={i} className="inline-block px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded">
+                        <span key={i} className="inline-block px-2 py-1 bg-brand-100 text-brand-800 text-xs rounded">
                           {feature}
                         </span>
                       ))}
@@ -315,7 +315,7 @@ export default function SurveyResultsPage() {
                 <p className="text-gray-500">Ainda não há respostas ao survey.</p>
                 <Link
                   href="/survey"
-                  className="inline-block mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700"
+                  className="inline-block mt-4 px-4 py-2 bg-brand-600 text-white rounded-lg text-sm hover:bg-brand-700"
                 >
                   Ver Survey
                 </Link>

--- a/src/app/aimi/page.tsx
+++ b/src/app/aimi/page.tsx
@@ -291,7 +291,7 @@ export default function AIMICalculatorPage() {
                   onClick={() => setLanguage(lang.code)}
                   className={`px-3 py-2 rounded-lg text-sm font-medium transition ${
                     language === lang.code
-                      ? "bg-blue-100 text-blue-700 border border-blue-200"
+                      ? "bg-brand-100 text-brand-700 border border-brand-200"
                       : "text-gray-600 hover:text-gray-900 hover:bg-gray-100"
                   }`}
                 >
@@ -323,7 +323,7 @@ export default function AIMICalculatorPage() {
                   placeholder="1500"
                   min="0"
                   step="100"
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -334,7 +334,7 @@ export default function AIMICalculatorPage() {
                 <select
                   value={municipality}
                   onChange={(e) => setMunicipality(e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 >
                   <option value="">{t.municipalityPlaceholder}</option>
                   {MUNICIPALITIES.map((muni) => (
@@ -352,7 +352,7 @@ export default function AIMICalculatorPage() {
                 <select
                   value={propertyCount}
                   onChange={(e) => setPropertyCount(e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 >
                   {[1,2,3,4,5,6,7,8,9,10].map((num) => (
                     <option key={num} value={num}>
@@ -452,7 +452,7 @@ export default function AIMICalculatorPage() {
 
         {/* Email Capture for AIMI Report */}
         {result.exempt && result.annualSavings > 0 && !emailSubmitted && (
-          <div className="mt-8 bg-gradient-to-r from-green-50 to-blue-50 rounded-xl border border-green-200 p-6">
+          <div className="mt-8 bg-gradient-to-r from-green-50 to-brand-50 rounded-xl border border-green-200 p-6">
             <div className="text-center">
               <div className="text-2xl mb-2">📧</div>
               <h3 className="text-lg font-semibold text-gray-900 mb-2">
@@ -470,12 +470,12 @@ export default function AIMICalculatorPage() {
                     onChange={(e) => setEmail(e.target.value)}
                     placeholder={t.emailPlaceholder}
                     required
-                    className="flex-1 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="flex-1 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                   />
                   <button
                     type="submit"
                     disabled={emailLoading || !email}
-                    className="px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                    className="px-6 py-3 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition"
                   >
                     {emailLoading ? t.sending : t.receiveReport}
                   </button>
@@ -526,29 +526,29 @@ export default function AIMICalculatorPage() {
         </div>
 
         {/* CTA to other calculators */}
-        <div className="mt-8 bg-blue-50 rounded-xl p-6 text-center">
-          <h3 className="text-lg font-semibold text-blue-900 mb-2">
+        <div className="mt-8 bg-brand-50 rounded-xl p-6 text-center">
+          <h3 className="text-lg font-semibold text-brand-900 mb-2">
             {t.ctaTitle}
           </h3>
-          <p className="text-blue-700 mb-4">
+          <p className="text-brand-700 mb-4">
             {t.ctaDescription}
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link
               href="/calculadora"
-              className="px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition"
+              className="px-6 py-3 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 transition"
             >
               {language === 'pt' ? 'Simulador Fiscal' : 'Tax Calculator'}
             </Link>
             <Link
               href="/calculadora-rendas"
-              className="px-6 py-3 border border-blue-300 text-blue-700 rounded-lg font-medium hover:bg-blue-50 transition"
+              className="px-6 py-3 border border-brand-300 text-brand-700 rounded-lg font-medium hover:bg-brand-50 transition"
             >
               {language === 'pt' ? 'Calculadora de Rendas' : 'Rent Calculator'}
             </Link>
             <Link
               href="/#waitlist"
-              className="px-6 py-3 border border-blue-300 text-blue-700 rounded-lg font-medium hover:bg-blue-50 transition"
+              className="px-6 py-3 border border-brand-300 text-brand-700 rounded-lg font-medium hover:bg-brand-50 transition"
             >
               {t.joinWaitlist}
             </Link>

--- a/src/app/blog/como-calcular-atualizacoes-renda-2026/page.tsx
+++ b/src/app/blog/como-calcular-atualizacoes-renda-2026/page.tsx
@@ -46,7 +46,7 @@ export default function AtualizacoesRenda2026Page() {
               <span className="px-3 py-1 bg-orange-100 text-orange-700 text-sm rounded-full font-medium">
                 Atualização Rendas
               </span>
-              <span className="px-3 py-1 bg-blue-100 text-blue-700 text-sm rounded-full font-medium">
+              <span className="px-3 py-1 bg-brand-100 text-brand-700 text-sm rounded-full font-medium">
                 Coeficiente INE
               </span>
               <span className="px-3 py-1 bg-green-100 text-green-700 text-sm rounded-full font-medium">
@@ -95,16 +95,16 @@ export default function AtualizacoesRenda2026Page() {
             <nav className="not-prose bg-gray-50 rounded-xl p-6 mb-8">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Índice</h3>
               <ol className="space-y-2 text-sm">
-                <li><a href="#o-que-e-atualizacao" className="text-blue-600 hover:text-blue-800">1. O Que É a Atualização de Rendas?</a></li>
-                <li><a href="#coeficiente-ine-2026" className="text-blue-600 hover:text-blue-800">2. Coeficiente INE 2026: O Valor Atual</a></li>
-                <li><a href="#nrau-regras" className="text-blue-600 hover:text-blue-800">3. Regras do NRAU para Atualização de Rendas</a></li>
-                <li><a href="#habitacional-vs-comercial" className="text-blue-600 hover:text-blue-800">4. Contratos Habitacionais vs. Comerciais</a></li>
-                <li><a href="#passo-a-passo" className="text-blue-600 hover:text-blue-800">5. Passo a Passo: Como Calcular</a></li>
-                <li><a href="#exemplos-praticos" className="text-blue-600 hover:text-blue-800">6. Exemplos Práticos com Cálculos</a></li>
-                <li><a href="#comunicacao-inquilino" className="text-blue-600 hover:text-blue-800">7. Como Comunicar ao Inquilino</a></li>
-                <li><a href="#excecoes-limites" className="text-blue-600 hover:text-blue-800">8. Exceções e Limites Legais</a></li>
-                <li><a href="#historico-coeficientes" className="text-blue-600 hover:text-blue-800">9. Histórico de Coeficientes INE</a></li>
-                <li><a href="#erros-comuns" className="text-blue-600 hover:text-blue-800">10. Erros Comuns a Evitar</a></li>
+                <li><a href="#o-que-e-atualizacao" className="text-brand-600 hover:text-brand-800">1. O Que É a Atualização de Rendas?</a></li>
+                <li><a href="#coeficiente-ine-2026" className="text-brand-600 hover:text-brand-800">2. Coeficiente INE 2026: O Valor Atual</a></li>
+                <li><a href="#nrau-regras" className="text-brand-600 hover:text-brand-800">3. Regras do NRAU para Atualização de Rendas</a></li>
+                <li><a href="#habitacional-vs-comercial" className="text-brand-600 hover:text-brand-800">4. Contratos Habitacionais vs. Comerciais</a></li>
+                <li><a href="#passo-a-passo" className="text-brand-600 hover:text-brand-800">5. Passo a Passo: Como Calcular</a></li>
+                <li><a href="#exemplos-praticos" className="text-brand-600 hover:text-brand-800">6. Exemplos Práticos com Cálculos</a></li>
+                <li><a href="#comunicacao-inquilino" className="text-brand-600 hover:text-brand-800">7. Como Comunicar ao Inquilino</a></li>
+                <li><a href="#excecoes-limites" className="text-brand-600 hover:text-brand-800">8. Exceções e Limites Legais</a></li>
+                <li><a href="#historico-coeficientes" className="text-brand-600 hover:text-brand-800">9. Histórico de Coeficientes INE</a></li>
+                <li><a href="#erros-comuns" className="text-brand-600 hover:text-brand-800">10. Erros Comuns a Evitar</a></li>
               </ol>
             </nav>
 
@@ -126,9 +126,9 @@ export default function AtualizacoesRenda2026Page() {
               de vida sem aumentos abusivos.
             </p>
 
-            <div className="not-prose bg-blue-50 border border-blue-200 rounded-xl p-6 mb-6">
-              <h4 className="text-blue-900 font-semibold mb-2">💡 Conceitos-Chave</h4>
-              <ul className="text-blue-800 space-y-1 text-sm">
+            <div className="not-prose bg-brand-50 border border-brand-200 rounded-xl p-6 mb-6">
+              <h4 className="text-brand-900 font-semibold mb-2">💡 Conceitos-Chave</h4>
+              <ul className="text-brand-800 space-y-1 text-sm">
                 <li>• <strong>Coeficiente INE:</strong> Percentagem máxima de aumento de renda, publicada anualmente</li>
                 <li>• <strong>NRAU:</strong> Lei n.º 6/2006 — regime legal do arrendamento urbano</li>
                 <li>• <strong>IPC:</strong> Índice de Preços no Consumidor, base do cálculo</li>
@@ -646,7 +646,7 @@ Com os melhores cumprimentos,
               <p className="text-gray-600 text-sm mb-4">
                 Guia completo sobre a nova taxa fixa de 10% e comparação de regimes fiscais.
               </p>
-              <span className="text-blue-600 text-sm font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-sm font-medium">Ler artigo →</span>
             </Link>
             <Link href="/blog/recibos-renda-eletronicos-guia-2026" className="border border-gray-200 rounded-xl p-6 hover:shadow-lg transition block">
               <h3 className="font-semibold text-gray-900 mb-2">
@@ -655,7 +655,7 @@ Com os melhores cumprimentos,
               <p className="text-gray-600 text-sm mb-4">
                 Como emitir recibos eletrónicos no Portal das Finanças, prazos e penalizações.
               </p>
-              <span className="text-blue-600 text-sm font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-sm font-medium">Ler artigo →</span>
             </Link>
           </div>
         </section>

--- a/src/app/blog/declaracao-irs-arrendamento-2026-guia-completo/page.tsx
+++ b/src/app/blog/declaracao-irs-arrendamento-2026-guia-completo/page.tsx
@@ -73,7 +73,7 @@ export default function DeclaracaoIRSArrendamentoPage() {
             </Link>
             <div className="mt-4">
               <div className="flex flex-wrap gap-2 mb-4">
-                <span className="px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded">IRS 2026</span>
+                <span className="px-2 py-1 bg-brand-100 text-brand-800 text-xs rounded">IRS 2026</span>
                 <span className="px-2 py-1 bg-green-100 text-green-800 text-xs rounded">Declaração Arrendamento</span>
                 <span className="px-2 py-1 bg-purple-100 text-purple-800 text-xs rounded">Anexo F</span>
                 <span className="px-2 py-1 bg-orange-100 text-orange-800 text-xs rounded">Portal Finanças</span>
@@ -99,12 +99,12 @@ export default function DeclaracaoIRSArrendamentoPage() {
           <div className="prose prose-gray max-w-none">
 
             {/* Introduction */}
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-8">
-              <h2 className="text-xl font-semibold text-blue-900 mb-3">📋 Sumário Executivo</h2>
-              <p className="text-blue-800 mb-4">
+            <div className="bg-brand-50 border border-brand-200 rounded-lg p-6 mb-8">
+              <h2 className="text-xl font-semibold text-brand-900 mb-3">📋 Sumário Executivo</h2>
+              <p className="text-brand-800 mb-4">
                 A declaração de IRS para rendimentos de arrendamento em 2026 apresenta mudanças significativas com a nova taxa de 10% e atualizações no Anexo F. Este guia completo cobre todo o processo, desde a preparação de documentos até ao envio final.
               </p>
-              <div className="grid md:grid-cols-2 gap-4 text-sm text-blue-700">
+              <div className="grid md:grid-cols-2 gap-4 text-sm text-brand-700">
                 <div>
                   <strong>🗓️ Prazos Críticos:</strong>
                   <ul className="mt-1 space-y-1">
@@ -132,17 +132,17 @@ export default function DeclaracaoIRSArrendamentoPage() {
                 <div>
                   <strong>Preparação:</strong>
                   <ul className="mt-1 space-y-1 text-gray-600">
-                    <li>• <a href="#documentos" className="hover:text-blue-600">Documentos necessários</a></li>
-                    <li>• <a href="#regime-tributacao" className="hover:text-blue-600">Escolha do regime</a></li>
-                    <li>• <a href="#calculo-rendimentos" className="hover:text-blue-600">Cálculo de rendimentos</a></li>
+                    <li>• <a href="#documentos" className="hover:text-brand-600">Documentos necessários</a></li>
+                    <li>• <a href="#regime-tributacao" className="hover:text-brand-600">Escolha do regime</a></li>
+                    <li>• <a href="#calculo-rendimentos" className="hover:text-brand-600">Cálculo de rendimentos</a></li>
                   </ul>
                 </div>
                 <div>
                   <strong>Declaração:</strong>
                   <ul className="mt-1 space-y-1 text-gray-600">
-                    <li>• <a href="#anexo-f" className="hover:text-blue-600">Preenchimento Anexo F</a></li>
-                    <li>• <a href="#portal-financas" className="hover:text-blue-600">Portal das Finanças</a></li>
-                    <li>• <a href="#erros-comuns" className="hover:text-blue-600">Erros a evitar</a></li>
+                    <li>• <a href="#anexo-f" className="hover:text-brand-600">Preenchimento Anexo F</a></li>
+                    <li>• <a href="#portal-financas" className="hover:text-brand-600">Portal das Finanças</a></li>
+                    <li>• <a href="#erros-comuns" className="hover:text-brand-600">Erros a evitar</a></li>
                   </ul>
                 </div>
               </div>
@@ -235,7 +235,7 @@ export default function DeclaracaoIRSArrendamentoPage() {
                       <li>• Menos vantajoso para imóveis com muitos custos</li>
                       <li>• Não permite amortizações</li>
                     </ul>
-                    <div className="bg-blue-100 p-3 rounded text-sm text-blue-800">
+                    <div className="bg-brand-100 p-3 rounded text-sm text-brand-800">
                       <strong>💡 Ideal para:</strong> Rendas altas com despesas baixas
                     </div>
                   </div>
@@ -263,7 +263,7 @@ export default function DeclaracaoIRSArrendamentoPage() {
                       <li>• Necessidade de comprovar todas as despesas</li>
                       <li>• Processo mais complexo</li>
                     </ul>
-                    <div className="bg-blue-100 p-3 rounded text-sm text-blue-800">
+                    <div className="bg-brand-100 p-3 rounded text-sm text-brand-800">
                       <strong>💡 Ideal para:</strong> Imóveis com muitas despesas dedutíveis
                     </div>
                   </div>
@@ -281,14 +281,14 @@ export default function DeclaracaoIRSArrendamentoPage() {
               </div>
             </div>
 
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-8">
-              <h3 className="text-lg font-semibold text-blue-900 mb-3">🧮 Calculadora de Regime Óptimo</h3>
-              <p className="text-blue-800 mb-4">
+            <div className="bg-brand-50 border border-brand-200 rounded-lg p-6 mb-8">
+              <h3 className="text-lg font-semibold text-brand-900 mb-3">🧮 Calculadora de Regime Óptimo</h3>
+              <p className="text-brand-800 mb-4">
                 Não tem a certeza de qual regime escolher? Utilize a nossa calculadora gratuita para comparar os 4 regimes e descobrir qual resulta numa menor carga fiscal.
               </p>
               <Link
                 href="/calculadora"
-                className="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition"
+                className="inline-block bg-brand-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-brand-700 transition"
               >
                 Calcular Regime Óptimo →
               </Link>
@@ -356,7 +356,7 @@ export default function DeclaracaoIRSArrendamentoPage() {
                     <h4 className="font-medium text-green-800 mb-3">Cálculos por Regime:</h4>
                     <div className="space-y-3 text-sm">
                       <div className="bg-white p-3 rounded border">
-                        <strong className="text-blue-700">Regime 10%:</strong>
+                        <strong className="text-brand-700">Regime 10%:</strong>
                         <div className="mt-1">
                           Rendimento: €10.400<br/>
                           Imposto: €1.040
@@ -417,12 +417,12 @@ export default function DeclaracaoIRSArrendamentoPage() {
                 <h3 className="text-lg font-semibold text-gray-900 mb-4">📋 Guia de Preenchimento Campo a Campo</h3>
 
                 <div className="space-y-4">
-                  <div className="bg-blue-50 p-4 rounded">
-                    <h4 className="font-medium text-blue-900 mb-2">Campo 401 - Rendimento Bruto (Regime Geral)</h4>
-                    <p className="text-blue-800 text-sm mb-2">
+                  <div className="bg-brand-50 p-4 rounded">
+                    <h4 className="font-medium text-brand-900 mb-2">Campo 401 - Rendimento Bruto (Regime Geral)</h4>
+                    <p className="text-brand-800 text-sm mb-2">
                       Soma de todas as rendas recebidas + encargos + outros proveitos para imóveis no regime geral.
                     </p>
-                    <div className="bg-blue-100 p-3 rounded text-sm text-blue-800">
+                    <div className="bg-brand-100 p-3 rounded text-sm text-brand-800">
                       <strong>💡 Dica:</strong> Inclua apenas rendimentos de imóveis que optem pelo regime geral ou de habitação.
                     </div>
                   </div>
@@ -487,16 +487,16 @@ export default function DeclaracaoIRSArrendamentoPage() {
             </p>
 
             <div className="space-y-6 mb-8">
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
-                <h3 className="text-lg font-semibold text-blue-900 mb-3">🔗 Acesso ao Portal</h3>
+              <div className="bg-brand-50 border border-brand-200 rounded-lg p-6">
+                <h3 className="text-lg font-semibold text-brand-900 mb-3">🔗 Acesso ao Portal</h3>
                 <div className="space-y-3">
-                  <p className="text-blue-800">
-                    <strong>URL:</strong> <span className="font-mono bg-blue-100 px-2 py-1 rounded">https://www.portaldasfinancas.gov.pt</span>
+                  <p className="text-brand-800">
+                    <strong>URL:</strong> <span className="font-mono bg-brand-100 px-2 py-1 rounded">https://www.portaldasfinancas.gov.pt</span>
                   </p>
                   <div className="grid md:grid-cols-2 gap-4 text-sm">
                     <div>
-                      <p className="font-medium text-blue-800 mb-2">Opções de Login:</p>
-                      <ul className="text-blue-700 space-y-1">
+                      <p className="font-medium text-brand-800 mb-2">Opções de Login:</p>
+                      <ul className="text-brand-700 space-y-1">
                         <li>• NIF + Senha</li>
                         <li>• Cartão de Cidadão</li>
                         <li>• Chave Móvel Digital</li>
@@ -504,8 +504,8 @@ export default function DeclaracaoIRSArrendamentoPage() {
                       </ul>
                     </div>
                     <div>
-                      <p className="font-medium text-blue-800 mb-2">Horários de Funcionamento:</p>
-                      <ul className="text-blue-700 space-y-1">
+                      <p className="font-medium text-brand-800 mb-2">Horários de Funcionamento:</p>
+                      <ul className="text-brand-700 space-y-1">
                         <li>• Segunda a Sexta: 07h00-22h00</li>
                         <li>• Sábados: 09h00-18h00</li>
                         <li>• Domingos: 09h00-15h00</li>
@@ -573,7 +573,7 @@ export default function DeclaracaoIRSArrendamentoPage() {
                     }
                   ].map((item, index) => (
                     <div key={index} className="flex gap-4 p-4 bg-gray-50 rounded-lg">
-                      <div className="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
+                      <div className="flex-shrink-0 w-8 h-8 bg-brand-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
                         {item.step}
                       </div>
                       <div>
@@ -686,7 +686,7 @@ export default function DeclaracaoIRSArrendamentoPage() {
               <h3 className="text-lg font-semibold text-gray-900 mb-4">🗓️ Datas Importantes para Senhorios</h3>
               <div className="space-y-3">
                 <div className="flex items-center gap-4 p-3 bg-white rounded border">
-                  <div className="text-blue-600 font-bold">1 ABR - 30 JUN</div>
+                  <div className="text-brand-600 font-bold">1 ABR - 30 JUN</div>
                   <div>
                     <span className="font-medium">Entrega da Declaração IRS 2025</span>
                     <div className="text-sm text-gray-600">Portal das Finanças disponível 24/7</div>
@@ -744,19 +744,19 @@ export default function DeclaracaoIRSArrendamentoPage() {
                 </div>
               </div>
 
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
-                <h3 className="text-lg font-semibold text-blue-900 mb-3">🔧 Ferramentas Gratuitas Senhorio</h3>
+              <div className="bg-brand-50 border border-brand-200 rounded-lg p-6">
+                <h3 className="text-lg font-semibold text-brand-900 mb-3">🔧 Ferramentas Gratuitas Senhorio</h3>
                 <div className="grid md:grid-cols-2 gap-4">
                   <div>
-                    <Link href="/calculadora" className="block bg-white border border-blue-200 p-4 rounded hover:shadow-md transition">
-                      <h4 className="font-medium text-blue-900 mb-2">Calculadora de Regimes</h4>
-                      <p className="text-blue-700 text-sm">Compare os 4 regimes fiscais e descubra qual poupa mais impostos</p>
+                    <Link href="/calculadora" className="block bg-white border border-brand-200 p-4 rounded hover:shadow-md transition">
+                      <h4 className="font-medium text-brand-900 mb-2">Calculadora de Regimes</h4>
+                      <p className="text-brand-700 text-sm">Compare os 4 regimes fiscais e descubra qual poupa mais impostos</p>
                     </Link>
                   </div>
                   <div>
-                    <Link href="/calculadora-rendas" className="block bg-white border border-blue-200 p-4 rounded hover:shadow-md transition">
-                      <h4 className="font-medium text-blue-900 mb-2">Calculadora de Atualizações</h4>
-                      <p className="text-blue-700 text-sm">Calcule atualizações de renda com o coeficiente INE oficial 2,24%</p>
+                    <Link href="/calculadora-rendas" className="block bg-white border border-brand-200 p-4 rounded hover:shadow-md transition">
+                      <h4 className="font-medium text-brand-900 mb-2">Calculadora de Atualizações</h4>
+                      <p className="text-brand-700 text-sm">Calcule atualizações de renda com o coeficiente INE oficial 2,24%</p>
                     </Link>
                   </div>
                 </div>
@@ -764,23 +764,23 @@ export default function DeclaracaoIRSArrendamentoPage() {
             </div>
 
             {/* CTA Section */}
-            <div className="bg-gradient-to-r from-blue-600 to-blue-700 rounded-lg p-8 text-center text-white mt-12">
+            <div className="bg-gradient-to-r from-brand-600 to-brand-700 rounded-lg p-8 text-center text-white mt-12">
               <h2 className="text-2xl font-bold mb-4">
                 Simplifique a Sua Declaração IRS 2026
               </h2>
-              <p className="text-blue-100 mb-6 max-w-2xl mx-auto">
+              <p className="text-brand-100 mb-6 max-w-2xl mx-auto">
                 Junte-se a milhares de senhorios que já usam as nossas ferramentas gratuitas para calcular impostos e otimizar a sua carga fiscal.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <Link
                   href="/calculadora"
-                  className="bg-white text-blue-700 px-6 py-3 rounded-lg font-medium hover:bg-gray-50 transition"
+                  className="bg-white text-brand-700 px-6 py-3 rounded-lg font-medium hover:bg-gray-50 transition"
                 >
                   Calcular Impostos Grátis
                 </Link>
                 <Link
                   href="/#waitlist"
-                  className="bg-blue-500 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-400 transition"
+                  className="bg-brand-500 text-white px-6 py-3 rounded-lg font-medium hover:bg-brand-400 transition"
                 >
                   Receber Alertas Fiscais
                 </Link>

--- a/src/app/blog/despesas-dedutiveis-arrendamento-2026/page.tsx
+++ b/src/app/blog/despesas-dedutiveis-arrendamento-2026/page.tsx
@@ -41,7 +41,7 @@ export default function DespesasDedutiveis2026Page() {
           {/* Article Header */}
           <header className="mb-8">
             <div className="flex flex-wrap gap-2 mb-4">
-              <span className="px-3 py-1 bg-blue-100 text-blue-700 text-sm rounded-full font-medium">
+              <span className="px-3 py-1 bg-brand-100 text-brand-700 text-sm rounded-full font-medium">
                 IRS 2026
               </span>
               <span className="px-3 py-1 bg-green-100 text-green-700 text-sm rounded-full font-medium">
@@ -63,7 +63,7 @@ export default function DespesasDedutiveis2026Page() {
               e valores reais.
             </p>
 
-            <div className="flex items-center gap-4 text-sm text-gray-500 border-l-4 border-blue-500 pl-4">
+            <div className="flex items-center gap-4 text-sm text-gray-500 border-l-4 border-brand-500 pl-4">
               <time dateTime="2026-04-04T10:00:00.000Z">4 de abril de 2026</time>
               <span>•</span>
               <span>13 minutos de leitura</span>
@@ -74,17 +74,17 @@ export default function DespesasDedutiveis2026Page() {
           <div className="prose prose-gray prose-lg max-w-none">
 
             {/* Calculator CTA */}
-            <div className="not-prose bg-blue-50 border border-blue-200 rounded-xl p-6 mb-8">
-              <h3 className="text-lg font-semibold text-blue-900 mb-2">
+            <div className="not-prose bg-brand-50 border border-brand-200 rounded-xl p-6 mb-8">
+              <h3 className="text-lg font-semibold text-brand-900 mb-2">
                 Calcule quanto poupa com as deduções
               </h3>
-              <p className="text-blue-700 mb-4 text-sm">
+              <p className="text-brand-700 mb-4 text-sm">
                 Introduza as suas rendas e despesas no nosso simulador e veja automaticamente
                 se compensa o regime de englobamento (com deduções) ou a taxa fixa de 10%.
               </p>
               <Link
                 href="/calculadora"
-                className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition text-sm"
+                className="inline-flex items-center px-4 py-2 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 transition text-sm"
               >
                 Abrir Simulador Fiscal Gratuito →
               </Link>
@@ -94,14 +94,14 @@ export default function DespesasDedutiveis2026Page() {
             <nav className="not-prose bg-gray-50 rounded-xl p-6 mb-8">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Índice</h3>
               <ol className="space-y-2 text-sm">
-                <li><a href="#quando-deduzir" className="text-blue-600 hover:text-blue-800">1. Quando Faz Sentido Deduzir Despesas?</a></li>
-                <li><a href="#despesas-permitidas" className="text-blue-600 hover:text-blue-800">2. Despesas Totalmente Dedutíveis</a></li>
-                <li><a href="#obras" className="text-blue-600 hover:text-blue-800">3. Obras e Reparações: Regras Especiais</a></li>
-                <li><a href="#imi-aimi" className="text-blue-600 hover:text-blue-800">4. IMI e AIMI: Dedução Parcial</a></li>
-                <li><a href="#nao-dedutivel" className="text-blue-600 hover:text-blue-800">5. O que NÃO Pode Deduzir</a></li>
-                <li><a href="#tabela-resumo" className="text-blue-600 hover:text-blue-800">6. Tabela Resumo Completa</a></li>
-                <li><a href="#exemplos" className="text-blue-600 hover:text-blue-800">7. Exemplos Práticos com Cálculos</a></li>
-                <li><a href="#documentacao" className="text-blue-600 hover:text-blue-800">8. Documentação Necessária</a></li>
+                <li><a href="#quando-deduzir" className="text-brand-600 hover:text-brand-800">1. Quando Faz Sentido Deduzir Despesas?</a></li>
+                <li><a href="#despesas-permitidas" className="text-brand-600 hover:text-brand-800">2. Despesas Totalmente Dedutíveis</a></li>
+                <li><a href="#obras" className="text-brand-600 hover:text-brand-800">3. Obras e Reparações: Regras Especiais</a></li>
+                <li><a href="#imi-aimi" className="text-brand-600 hover:text-brand-800">4. IMI e AIMI: Dedução Parcial</a></li>
+                <li><a href="#nao-dedutivel" className="text-brand-600 hover:text-brand-800">5. O que NÃO Pode Deduzir</a></li>
+                <li><a href="#tabela-resumo" className="text-brand-600 hover:text-brand-800">6. Tabela Resumo Completa</a></li>
+                <li><a href="#exemplos" className="text-brand-600 hover:text-brand-800">7. Exemplos Práticos com Cálculos</a></li>
+                <li><a href="#documentacao" className="text-brand-600 hover:text-brand-800">8. Documentação Necessária</a></li>
               </ol>
             </nav>
 
@@ -228,7 +228,7 @@ export default function DespesasDedutiveis2026Page() {
 
             <p>
               Utilize a nossa{" "}
-              <Link href="/aimi" className="text-blue-600 hover:text-blue-700 underline">
+              <Link href="/aimi" className="text-brand-600 hover:text-brand-700 underline">
                 calculadora de isenção AIMI
               </Link>{" "}
               para verificar se qualifica para a isenção de 2026.
@@ -328,9 +328,9 @@ export default function DespesasDedutiveis2026Page() {
                   <div>
                     <p className="font-medium text-gray-700 mb-2">Comparação fiscal:</p>
                     <ul className="space-y-1">
-                      <li className="text-blue-700">• Taxa 10%: €11.400 × 10% = <strong>€1.140</strong></li>
+                      <li className="text-brand-700">• Taxa 10%: €11.400 × 10% = <strong>€1.140</strong></li>
                       <li className="text-green-700">• Englobamento (28.5%): €7.270 × 28.5% = <strong>€2.072</strong></li>
-                      <li className="text-blue-700 font-semibold mt-2">→ Taxa 10% poupa €932 neste caso</li>
+                      <li className="text-brand-700 font-semibold mt-2">→ Taxa 10% poupa €932 neste caso</li>
                     </ul>
                   </div>
                 </div>
@@ -356,15 +356,15 @@ export default function DespesasDedutiveis2026Page() {
                     <ul className="space-y-1">
                       <li className="text-orange-700">• Taxa 10%: €16.800 × 10% = <strong>€1.680</strong></li>
                       <li className="text-green-700">• Englobamento (35%): €7.000 × 35% = <strong>€2.450</strong></li>
-                      <li className="text-blue-700 font-semibold mt-2">→ Neste caso, taxa 10% ainda é melhor</li>
+                      <li className="text-brand-700 font-semibold mt-2">→ Neste caso, taxa 10% ainda é melhor</li>
                       <li className="text-gray-500 text-xs mt-1">Mas com despesas ainda maiores ou taxa marginal mais baixa, o englobamento pode ganhar</li>
                     </ul>
                   </div>
                 </div>
               </div>
 
-              <div className="bg-blue-50 border border-blue-200 rounded-xl p-5">
-                <p className="text-blue-800 text-sm">
+              <div className="bg-brand-50 border border-brand-200 rounded-xl p-5">
+                <p className="text-brand-800 text-sm">
                   <strong>Conclusão prática:</strong> Na maioria dos casos em 2026, a taxa de 10%
                   acaba por ser mais vantajosa porque incide sobre o bruto mas a taxa é muito baixa.
                   O englobamento só compensa se tiver despesas muito elevadas (acima de 40-50%
@@ -407,24 +407,24 @@ export default function DespesasDedutiveis2026Page() {
               </div>
             </div>
 
-            <div className="not-prose mt-12 bg-gradient-to-r from-blue-600 to-indigo-600 rounded-xl p-8 text-white text-center">
+            <div className="not-prose mt-12 bg-gradient-to-r from-brand-600 to-brand-700 rounded-xl p-8 text-white text-center">
               <h3 className="text-xl font-bold mb-3">
                 Não deixe dinheiro na mesa
               </h3>
-              <p className="text-blue-100 mb-6 text-sm max-w-lg mx-auto">
+              <p className="text-brand-100 mb-6 text-sm max-w-lg mx-auto">
                 O simulador fiscal do Senhorio calcula automaticamente se vale a pena deduzir despesas
                 ou optar pela taxa fixa de 10%. Em segundos, tem a resposta.
               </p>
               <div className="flex flex-col sm:flex-row gap-3 justify-center">
                 <Link
                   href="/calculadora"
-                  className="px-6 py-3 bg-white text-blue-600 rounded-lg font-medium hover:bg-gray-100 transition text-sm"
+                  className="px-6 py-3 bg-white text-brand-600 rounded-lg font-medium hover:bg-gray-100 transition text-sm"
                 >
                   Simular Agora — É Grátis
                 </Link>
                 <Link
                   href="/blog/declaracao-irs-arrendamento-2026-guia-completo"
-                  className="px-6 py-3 border border-white text-white rounded-lg font-medium hover:bg-white hover:text-blue-600 transition text-sm"
+                  className="px-6 py-3 border border-white text-white rounded-lg font-medium hover:bg-white hover:text-brand-600 transition text-sm"
                 >
                   Ver Guia Declaração IRS
                 </Link>
@@ -442,21 +442,21 @@ export default function DespesasDedutiveis2026Page() {
                 Declaração IRS Arrendamento 2026: Passo a Passo
               </h3>
               <p className="text-gray-500 text-xs mb-3">Anexo F, Portal das Finanças e prazos.</p>
-              <span className="text-blue-600 text-xs font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-xs font-medium">Ler artigo →</span>
             </Link>
             <Link href="/blog/imposto-10-porcento-rendas-portugal-2026" className="border border-gray-200 rounded-xl p-5 hover:shadow-lg transition block">
               <h3 className="font-semibold text-gray-900 mb-2 text-sm">
                 Imposto 10% Rendas Portugal 2026
               </h3>
               <p className="text-gray-500 text-xs mb-3">Tudo sobre a nova taxa fixa.</p>
-              <span className="text-blue-600 text-xs font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-xs font-medium">Ler artigo →</span>
             </Link>
             <Link href="/blog/isencao-aimi-2026-qualificar-nova-isencao" className="border border-gray-200 rounded-xl p-5 hover:shadow-lg transition block">
               <h3 className="font-semibold text-gray-900 mb-2 text-sm">
                 Isenção AIMI 2026: Como Qualificar
               </h3>
               <p className="text-gray-500 text-xs mb-3">Critérios e poupanças estimadas.</p>
-              <span className="text-blue-600 text-xs font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-xs font-medium">Ler artigo →</span>
             </Link>
           </div>
         </section>

--- a/src/app/blog/imposto-10-porcento-rendas-portugal-2026/page.tsx
+++ b/src/app/blog/imposto-10-porcento-rendas-portugal-2026/page.tsx
@@ -26,7 +26,7 @@ export default function Imposto10PorcentoRendasPortugal() {
           </Link>
           <div className="mt-4">
             <div className="flex flex-wrap gap-2 mb-3">
-              <span className="px-2 py-1 bg-blue-100 text-blue-700 text-xs rounded font-medium">
+              <span className="px-2 py-1 bg-brand-100 text-brand-700 text-xs rounded font-medium">
                 Imposto 10%
               </span>
               <span className="px-2 py-1 bg-green-100 text-green-700 text-xs rounded font-medium">
@@ -56,15 +56,15 @@ export default function Imposto10PorcentoRendasPortugal() {
         <div className="prose prose-lg prose-gray max-w-none">
 
           {/* Introduction */}
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-semibold text-blue-900 mb-3">
+          <div className="bg-brand-50 border border-brand-200 rounded-lg p-6 mb-8">
+            <h2 className="text-xl font-semibold text-brand-900 mb-3">
               🎯 Resumo Executivo
             </h2>
-            <p className="text-blue-800 mb-2">
+            <p className="text-brand-800 mb-2">
               O <strong>imposto de 10% sobre rendas em Portugal</strong> é uma das quatro opções fiscais disponíveis para senhorios em 2026.
               É uma taxa fixa aplicada sobre o valor bruto das rendas, sem deduções.
             </p>
-            <ul className="text-blue-800 space-y-1 text-sm">
+            <ul className="text-brand-800 space-y-1 text-sm">
               <li>✅ <strong>Vantajoso para:</strong> Senhorios com poucas despesas dedutíveis</li>
               <li>✅ <strong>Simplicidade:</strong> Sem necessidade de guardar faturas</li>
               <li>❌ <strong>Desvantagem:</strong> Não permite dedução de despesas reais</li>
@@ -89,25 +89,25 @@ export default function Imposto10PorcentoRendasPortugal() {
           <div className="bg-gray-50 rounded-lg p-6 my-6">
             <ol className="space-y-3">
               <li className="flex items-start">
-                <span className="bg-blue-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold mr-3 mt-0.5">1</span>
+                <span className="bg-brand-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold mr-3 mt-0.5">1</span>
                 <div>
                   <strong>Taxa fixa de 10%</strong> - Sobre rendas brutas (sem deduções)
                 </div>
               </li>
               <li className="flex items-start">
-                <span className="bg-blue-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold mr-3 mt-0.5">2</span>
+                <span className="bg-brand-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold mr-3 mt-0.5">2</span>
                 <div>
                   <strong>Englobamento</strong> - Rendas somadas aos outros rendimentos
                 </div>
               </li>
               <li className="flex items-start">
-                <span className="bg-blue-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold mr-3 mt-0.5">3</span>
+                <span className="bg-brand-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold mr-3 mt-0.5">3</span>
                 <div>
                   <strong>Regime simplificado</strong> - Com dedução automática de 65%
                 </div>
               </li>
               <li className="flex items-start">
-                <span className="bg-blue-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold mr-3 mt-0.5">4</span>
+                <span className="bg-brand-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold mr-3 mt-0.5">4</span>
                 <div>
                   <strong>Contabilidade organizada</strong> - Com dedução de despesas reais
                 </div>
@@ -173,9 +173,9 @@ export default function Imposto10PorcentoRendasPortugal() {
           </p>
 
           <div className="space-y-6 my-8">
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
-              <h3 className="font-semibold text-blue-900 mb-3">🏠 Propriedades Novas ou Bem Conservadas</h3>
-              <p className="text-blue-800">
+            <div className="bg-brand-50 border border-brand-200 rounded-lg p-6">
+              <h3 className="font-semibold text-brand-900 mb-3">🏠 Propriedades Novas ou Bem Conservadas</h3>
+              <p className="text-brand-800">
                 Imóveis com poucas despesas de manutenção, onde as despesas dedutíveis são inferiores a 35% das rendas brutas.
               </p>
             </div>
@@ -213,8 +213,8 @@ export default function Imposto10PorcentoRendasPortugal() {
                 <p className="font-semibold text-gray-800">Comparação de Regimes:</p>
                 <div className="grid md:grid-cols-2 gap-4 mt-2">
                   <div>
-                    <p className="text-sm font-medium text-blue-700">Taxa 10%:</p>
-                    <p className="text-lg font-bold text-blue-800">€900</p>
+                    <p className="text-sm font-medium text-brand-700">Taxa 10%:</p>
+                    <p className="text-lg font-bold text-brand-800">€900</p>
                   </div>
                   <div>
                     <p className="text-sm font-medium text-gray-700">Simplificado (35% ded.):</p>
@@ -243,8 +243,8 @@ export default function Imposto10PorcentoRendasPortugal() {
                 <p className="font-semibold text-gray-800">Comparação de Regimes:</p>
                 <div className="grid md:grid-cols-2 gap-4 mt-2">
                   <div>
-                    <p className="text-sm font-medium text-blue-700">Taxa 10%:</p>
-                    <p className="text-lg font-bold text-blue-800">€1.440</p>
+                    <p className="text-sm font-medium text-brand-700">Taxa 10%:</p>
+                    <p className="text-lg font-bold text-brand-800">€1.440</p>
                   </div>
                   <div>
                     <p className="text-sm font-medium text-gray-700">Contab. Organizada:</p>
@@ -334,24 +334,24 @@ export default function Imposto10PorcentoRendasPortugal() {
           </div>
 
           {/* CTA Section */}
-          <div className="bg-gradient-to-r from-blue-50 to-blue-100 border border-blue-200 rounded-xl p-8 my-12 text-center">
-            <h2 className="text-2xl font-bold text-blue-900 mb-4">
+          <div className="bg-gradient-to-r from-brand-50 to-brand-100 border border-brand-200 rounded-xl p-8 my-12 text-center">
+            <h2 className="text-2xl font-bold text-brand-900 mb-4">
               💡 Calcule o Seu Imposto de Rendas
             </h2>
-            <p className="text-blue-800 mb-6">
+            <p className="text-brand-800 mb-6">
               Use a nossa calculadora gratuita para comparar todos os regimes fiscais e descobrir
               qual é mais vantajoso para a sua situação.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link
                 href="/calculadora"
-                className="px-8 py-4 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition inline-flex items-center justify-center"
+                className="px-8 py-4 bg-brand-600 text-white rounded-lg font-semibold hover:bg-brand-700 transition inline-flex items-center justify-center"
               >
                 🧮 Calculadora Fiscal Gratuita
               </Link>
               <Link
                 href="/calculadora-rendas"
-                className="px-8 py-4 border-2 border-blue-600 text-blue-600 rounded-lg font-semibold hover:bg-blue-50 transition inline-flex items-center justify-center"
+                className="px-8 py-4 border-2 border-brand-600 text-brand-600 rounded-lg font-semibold hover:bg-brand-50 transition inline-flex items-center justify-center"
               >
                 📈 Calculadora de Rendas
               </Link>
@@ -381,7 +381,7 @@ export default function Imposto10PorcentoRendasPortugal() {
           </div>
 
           <p>
-            <strong>Recomendação:</strong> Use a nossa <Link href="/calculadora" className="text-blue-600 hover:text-blue-800 underline">calculadora fiscal gratuita</Link> para
+            <strong>Recomendação:</strong> Use a nossa <Link href="/calculadora" className="text-brand-600 hover:text-brand-800 underline">calculadora fiscal gratuita</Link> para
             comparar todos os regimes e tomar uma decisão informada sobre o seu imposto de rendas em 2026.
           </p>
 

--- a/src/app/blog/irs-2026-guia-completo-simulador/page.tsx
+++ b/src/app/blog/irs-2026-guia-completo-simulador/page.tsx
@@ -86,18 +86,18 @@ export default function IRS2026GuiaCompletoSimulador() {
         <main className="max-w-4xl mx-auto px-6 py-12">
           <article>
             {/* Alert Banner */}
-            <div className="bg-blue-50 border-l-4 border-blue-400 p-6 mb-8">
+            <div className="bg-brand-50 border-l-4 border-brand-400 p-6 mb-8">
               <div className="flex">
                 <div className="flex-shrink-0">
-                  <svg className="h-5 w-5 text-blue-400" viewBox="0 0 20 20" fill="currentColor">
+                  <svg className="h-5 w-5 text-brand-400" viewBox="0 0 20 20" fill="currentColor">
                     <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
                   </svg>
                 </div>
                 <div className="ml-3">
-                  <h3 className="text-sm font-medium text-blue-800">
+                  <h3 className="text-sm font-medium text-brand-800">
                     🎯 IRS 2026: Escolha o Regime Fiscal Ideal
                   </h3>
-                  <div className="mt-2 text-sm text-blue-700">
+                  <div className="mt-2 text-sm text-brand-700">
                     <p>
                       Este guia completo explica os <strong>3 regimes fiscais</strong> disponíveis para senhorios em 2026.
                       Use o nosso <Link href="/simulador-irs" className="font-medium underline">simulador fiscal gratuito</Link> para encontrar a melhor opção para o seu caso.
@@ -115,7 +115,7 @@ export default function IRS2026GuiaCompletoSimulador() {
                 <span>25 min de leitura</span>
                 <span>•</span>
                 <div className="flex flex-wrap gap-2">
-                  <span className="bg-blue-100 text-blue-800 px-2 py-1 rounded">IRS 2026</span>
+                  <span className="bg-brand-100 text-brand-800 px-2 py-1 rounded">IRS 2026</span>
                   <span className="bg-green-100 text-green-800 px-2 py-1 rounded">RSAA 0%</span>
                   <span className="bg-orange-100 text-orange-800 px-2 py-1 rounded">Taxa 10%</span>
                   <span className="bg-purple-100 text-purple-800 px-2 py-1 rounded">Regime Geral</span>
@@ -141,19 +141,19 @@ export default function IRS2026GuiaCompletoSimulador() {
                 <div>
                   <h3 className="font-medium text-gray-900 mb-2">Regimes Fiscais</h3>
                   <ul className="text-sm text-gray-600 space-y-1">
-                    <li><a href="#rsaa-0" className="hover:text-blue-600">• RSAA 0%</a></li>
-                    <li><a href="#renda-moderada-10" className="hover:text-blue-600">• Renda Moderada 10%</a></li>
-                    <li><a href="#regime-geral-25" className="hover:text-blue-600">• Regime Geral 25%</a></li>
-                    <li><a href="#efeito-degrau" className="hover:text-blue-600">• Efeito Degrau €2.300</a></li>
+                    <li><a href="#rsaa-0" className="hover:text-brand-600">• RSAA 0%</a></li>
+                    <li><a href="#renda-moderada-10" className="hover:text-brand-600">• Renda Moderada 10%</a></li>
+                    <li><a href="#regime-geral-25" className="hover:text-brand-600">• Regime Geral 25%</a></li>
+                    <li><a href="#efeito-degrau" className="hover:text-brand-600">• Efeito Degrau €2.300</a></li>
                   </ul>
                 </div>
                 <div>
                   <h3 className="font-medium text-gray-900 mb-2">Ferramentas Práticas</h3>
                   <ul className="text-sm text-gray-600 space-y-1">
-                    <li><a href="#exemplos-praticos" className="hover:text-blue-600">• Exemplos Práticos</a></li>
-                    <li><a href="#prazos-entrega" className="hover:text-blue-600">• Prazos de Entrega</a></li>
-                    <li><a href="#simulador" className="hover:text-blue-600">• Simulador Fiscal</a></li>
-                    <li><a href="#estrategias" className="hover:text-blue-600">• Estratégias de Optimização</a></li>
+                    <li><a href="#exemplos-praticos" className="hover:text-brand-600">• Exemplos Práticos</a></li>
+                    <li><a href="#prazos-entrega" className="hover:text-brand-600">• Prazos de Entrega</a></li>
+                    <li><a href="#simulador" className="hover:text-brand-600">• Simulador Fiscal</a></li>
+                    <li><a href="#estrategias" className="hover:text-brand-600">• Estratégias de Optimização</a></li>
                   </ul>
                 </div>
               </div>
@@ -175,16 +175,16 @@ export default function IRS2026GuiaCompletoSimulador() {
             </section>
 
             {/* CTA to Simulator */}
-            <div className="bg-gradient-to-r from-blue-500 to-blue-600 rounded-lg p-8 text-center mb-12">
+            <div className="bg-gradient-to-r from-brand-500 to-brand-600 rounded-lg p-8 text-center mb-12">
               <h2 className="text-2xl font-bold text-white mb-4">
                 🧮 Calcule Agora o Seu IRS 2026
               </h2>
-              <p className="text-blue-100 mb-6">
+              <p className="text-brand-100 mb-6">
                 Compare os 3 regimes fiscais instantaneamente com o nosso simulador gratuito
               </p>
               <Link
                 href="/simulador-irs"
-                className="inline-block bg-white text-blue-600 font-semibold px-8 py-3 rounded-lg hover:bg-blue-50 transition"
+                className="inline-block bg-white text-brand-600 font-semibold px-8 py-3 rounded-lg hover:bg-brand-50 transition"
               >
                 Aceder ao Simulador Fiscal Gratuito →
               </Link>
@@ -500,8 +500,8 @@ export default function IRS2026GuiaCompletoSimulador() {
                     </ul>
                   </div>
                 </div>
-                <div className="mt-4 p-3 bg-blue-50 rounded">
-                  <p className="text-sm text-blue-700">
+                <div className="mt-4 p-3 bg-brand-50 rounded">
+                  <p className="text-sm text-brand-700">
                     <strong>Nota:</strong> No regime geral, o valor exato depende dos outros rendimentos do agregado.
                     Esta simulação assume um cenário típico.
                   </p>
@@ -613,22 +613,22 @@ export default function IRS2026GuiaCompletoSimulador() {
                 5. Prazos de Entrega do IRS 2026
               </h2>
 
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-6">
-                <h3 className="text-lg font-semibold text-blue-800 mb-3">
+              <div className="bg-brand-50 border border-brand-200 rounded-lg p-6 mb-6">
+                <h3 className="text-lg font-semibold text-brand-800 mb-3">
                   📅 Calendário Fiscal 2026
                 </h3>
                 <div className="grid md:grid-cols-2 gap-6">
                   <div>
-                    <h4 className="font-medium text-blue-800 mb-2">Prazos Principais</h4>
-                    <ul className="text-blue-700 space-y-1">
+                    <h4 className="font-medium text-brand-800 mb-2">Prazos Principais</h4>
+                    <ul className="text-brand-700 space-y-1">
                       <li>• <strong>Início:</strong> 1 de abril de 2027</li>
                       <li>• <strong>Fim:</strong> 30 de junho de 2027</li>
                       <li>• <strong>Via electrónica:</strong> Até 31 de julho de 2027</li>
                     </ul>
                   </div>
                   <div>
-                    <h4 className="font-medium text-blue-800 mb-2">Datas Importantes</h4>
-                    <ul className="text-blue-700 space-y-1">
+                    <h4 className="font-medium text-brand-800 mb-2">Datas Importantes</h4>
+                    <ul className="text-brand-700 space-y-1">
                       <li>• <strong>1º pagamento:</strong> 31 de julho de 2027</li>
                       <li>• <strong>2º pagamento:</strong> 15 de setembro de 2027</li>
                       <li>• <strong>3º pagamento:</strong> 15 de dezembro de 2027</li>
@@ -721,8 +721,8 @@ export default function IRS2026GuiaCompletoSimulador() {
                     </div>
                   </div>
 
-                  <div className="mt-4 p-3 bg-blue-50 rounded">
-                    <p className="text-sm text-blue-700">
+                  <div className="mt-4 p-3 bg-brand-50 rounded">
+                    <p className="text-sm text-brand-700">
                       <strong>Recomendação:</strong> Se João pretende manter o arrendamento estável por 5+ anos
                       e para habitação permanente, o RSAA oferece uma poupança de €2.520/ano (€12.600 em 5 anos).
                     </p>
@@ -770,8 +770,8 @@ export default function IRS2026GuiaCompletoSimulador() {
                     </div>
                   </div>
 
-                  <div className="mt-4 p-3 bg-blue-50 rounded">
-                    <p className="text-sm text-blue-700">
+                  <div className="mt-4 p-3 bg-brand-50 rounded">
+                    <p className="text-sm text-brand-700">
                       <strong>Nota:</strong> Com renda superior a €2.300, apenas o regime geral é possível.
                       As despesas elevadas tornam-no mais atrativo neste caso específico.
                     </p>
@@ -921,9 +921,9 @@ export default function IRS2026GuiaCompletoSimulador() {
 
               <div className="grid md:grid-cols-2 gap-6">
                 <div className="space-y-4">
-                  <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-                    <h4 className="font-semibold text-blue-800 mb-2">📅 Timing Estratégico</h4>
-                    <ul className="text-sm text-blue-700 space-y-1">
+                  <div className="bg-brand-50 border border-brand-200 rounded-lg p-4">
+                    <h4 className="font-semibold text-brand-800 mb-2">📅 Timing Estratégico</h4>
+                    <ul className="text-sm text-brand-700 space-y-1">
                       <li>• Concentrar obras em anos específicos</li>
                       <li>• Planear aquisições e vendas</li>
                       <li>• Distribuir rendimentos entre anos</li>
@@ -1002,23 +1002,23 @@ export default function IRS2026GuiaCompletoSimulador() {
             </section>
 
             {/* Final CTA */}
-            <div className="text-center bg-gradient-to-r from-blue-500 to-blue-600 rounded-lg p-8 text-white">
+            <div className="text-center bg-gradient-to-r from-brand-500 to-brand-600 rounded-lg p-8 text-white">
               <h2 className="text-2xl font-bold mb-4">
                 Optimize o Seu IRS 2026 Agora
               </h2>
-              <p className="text-blue-100 mb-6">
+              <p className="text-brand-100 mb-6">
                 Não deixe para última hora. Use o nosso simulador fiscal e tome decisões informadas sobre o seu arrendamento.
               </p>
               <div className="space-y-4 md:space-y-0 md:space-x-4 md:flex md:justify-center">
                 <Link
                   href="/simulador-irs"
-                  className="inline-block bg-white text-blue-600 font-semibold px-8 py-3 rounded-lg hover:bg-blue-50 transition"
+                  className="inline-block bg-white text-brand-600 font-semibold px-8 py-3 rounded-lg hover:bg-brand-50 transition"
                 >
                   Calcular o Meu IRS →
                 </Link>
                 <Link
                   href="/blog"
-                  className="inline-block bg-blue-700 text-white font-semibold px-8 py-3 rounded-lg hover:bg-blue-800 transition"
+                  className="inline-block bg-brand-700 text-white font-semibold px-8 py-3 rounded-lg hover:bg-brand-800 transition"
                 >
                   Mais Guias Fiscais
                 </Link>
@@ -1040,7 +1040,7 @@ export default function IRS2026GuiaCompletoSimulador() {
                 <div className="mt-4 md:mt-0">
                   <Link
                     href="/blog"
-                    className="text-sm text-blue-600 hover:text-blue-800 transition"
+                    className="text-sm text-brand-600 hover:text-brand-800 transition"
                   >
                     ← Voltar ao Blog
                   </Link>

--- a/src/app/blog/irs-arrendamento-2026-nova-taxa-10-porcento/page.tsx
+++ b/src/app/blog/irs-arrendamento-2026-nova-taxa-10-porcento/page.tsx
@@ -42,7 +42,7 @@ export default function IRSArrendamento2026Page() {
           {/* Article Header */}
           <header className="mb-8">
             <div className="flex flex-wrap gap-2 mb-4">
-              <span className="px-3 py-1 bg-blue-100 text-blue-700 text-sm rounded-full font-medium">
+              <span className="px-3 py-1 bg-brand-100 text-brand-700 text-sm rounded-full font-medium">
                 IRS 2026
               </span>
               <span className="px-3 py-1 bg-green-100 text-green-700 text-sm rounded-full font-medium">
@@ -63,7 +63,7 @@ export default function IRSArrendamento2026Page() {
               corretamente o seu IRS sobre rendimentos de arrendamento.
             </p>
 
-            <div className="flex items-center gap-4 text-sm text-gray-500 border-l-4 border-blue-500 pl-4">
+            <div className="flex items-center gap-4 text-sm text-gray-500 border-l-4 border-brand-500 pl-4">
               <time dateTime="2026-03-21T10:00:00.000Z">
                 21 de março de 2026
               </time>
@@ -75,16 +75,16 @@ export default function IRSArrendamento2026Page() {
           {/* Content */}
           <div className="prose prose-gray prose-lg max-w-none">
             {/* Quick Calculator CTA */}
-            <div className="not-prose bg-blue-50 border border-blue-200 rounded-xl p-6 mb-8">
-              <h3 className="text-lg font-semibold text-blue-900 mb-2">
+            <div className="not-prose bg-brand-50 border border-brand-200 rounded-xl p-6 mb-8">
+              <h3 className="text-lg font-semibold text-brand-900 mb-2">
                 🧮 Calcule o Seu IRS Agora
               </h3>
-              <p className="text-blue-700 mb-4">
+              <p className="text-brand-700 mb-4">
                 Use o nosso simulador gratuito para comparar as diferentes opções fiscais de 2026.
               </p>
               <Link
                 href="/calculadora"
-                className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition"
+                className="inline-flex items-center px-4 py-2 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 transition"
               >
                 Abrir Simulador IRS 2026 →
               </Link>
@@ -94,13 +94,13 @@ export default function IRSArrendamento2026Page() {
             <nav className="not-prose bg-gray-50 rounded-xl p-6 mb-8">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Índice</h3>
               <ol className="space-y-2 text-sm">
-                <li><a href="#novidades-2026" className="text-blue-600 hover:text-blue-800">1. Principais Novidades Fiscais de 2026</a></li>
-                <li><a href="#taxa-10-porcento" className="text-blue-600 hover:text-blue-800">2. Nova Taxa de 10%: Como Funciona</a></li>
-                <li><a href="#regimes-fiscais" className="text-blue-600 hover:text-blue-800">3. Comparação dos Regimes Fiscais</a></li>
-                <li><a href="#agregacao-familiar" className="text-blue-600 hover:text-blue-800">4. Agregação Familiar: Novas Regras</a></li>
-                <li><a href="#calculadora-pratica" className="text-blue-600 hover:text-blue-800">5. Como Calcular o Seu IRS</a></li>
-                <li><a href="#exemplos-praticos" className="text-blue-600 hover:text-blue-800">6. Exemplos Práticos</a></li>
-                <li><a href="#deadlines-obrigacoes" className="text-blue-600 hover:text-blue-800">7. Prazos e Obrigações</a></li>
+                <li><a href="#novidades-2026" className="text-brand-600 hover:text-brand-800">1. Principais Novidades Fiscais de 2026</a></li>
+                <li><a href="#taxa-10-porcento" className="text-brand-600 hover:text-brand-800">2. Nova Taxa de 10%: Como Funciona</a></li>
+                <li><a href="#regimes-fiscais" className="text-brand-600 hover:text-brand-800">3. Comparação dos Regimes Fiscais</a></li>
+                <li><a href="#agregacao-familiar" className="text-brand-600 hover:text-brand-800">4. Agregação Familiar: Novas Regras</a></li>
+                <li><a href="#calculadora-pratica" className="text-brand-600 hover:text-brand-800">5. Como Calcular o Seu IRS</a></li>
+                <li><a href="#exemplos-praticos" className="text-brand-600 hover:text-brand-800">6. Exemplos Práticos</a></li>
+                <li><a href="#deadlines-obrigacoes" className="text-brand-600 hover:text-brand-800">7. Prazos e Obrigações</a></li>
               </ol>
             </nav>
 
@@ -259,7 +259,7 @@ export default function IRSArrendamento2026Page() {
                   </div>
                   <div>
                     <p><strong>Melhor opção: Englobamento</strong></p>
-                    <ul className="text-blue-600 space-y-1">
+                    <ul className="text-brand-600 space-y-1">
                       <li>• Rendimento tributável: €10,000</li>
                       <li>• Aproveitamento de deduções</li>
                       <li>• Menor carga fiscal</li>
@@ -282,9 +282,9 @@ export default function IRSArrendamento2026Page() {
                   </ul>
                 </div>
 
-                <div className="bg-blue-50 border border-blue-200 rounded-xl p-6">
-                  <h4 className="text-blue-900 font-semibold mb-3">📋 Documentos Necessários</h4>
-                  <ul className="text-blue-800 space-y-2 text-sm">
+                <div className="bg-brand-50 border border-brand-200 rounded-xl p-6">
+                  <h4 className="text-brand-900 font-semibold mb-3">📋 Documentos Necessários</h4>
+                  <ul className="text-brand-800 space-y-2 text-sm">
                     <li>• Recibos de renda pagos</li>
                     <li>• Faturas de despesas dedutíveis</li>
                     <li>• Caderneta predial</li>
@@ -294,23 +294,23 @@ export default function IRSArrendamento2026Page() {
               </div>
             </div>
 
-            <div className="not-prose mt-12 bg-gradient-to-r from-blue-500 to-purple-600 rounded-xl p-8 text-white text-center">
+            <div className="not-prose mt-12 bg-gradient-to-r from-brand-500 to-purple-600 rounded-xl p-8 text-white text-center">
               <h3 className="text-xl font-bold mb-4">
                 Simplifique a Sua Gestão Fiscal
               </h3>
-              <p className="mb-6 text-blue-100">
+              <p className="mb-6 text-brand-100">
                 O Senhorio ajuda a calcular, comparar e otimizar os seus impostos automaticamente.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <Link
                   href="/calculadora"
-                  className="px-6 py-3 bg-white text-blue-600 rounded-lg font-medium hover:bg-gray-100 transition"
+                  className="px-6 py-3 bg-white text-brand-600 rounded-lg font-medium hover:bg-gray-100 transition"
                 >
                   Usar Calculadora Gratuita
                 </Link>
                 <Link
                   href="/"
-                  className="px-6 py-3 border border-white text-white rounded-lg font-medium hover:bg-white hover:text-blue-600 transition"
+                  className="px-6 py-3 border border-white text-white rounded-lg font-medium hover:bg-white hover:text-brand-600 transition"
                 >
                   Saber Mais sobre o Senhorio
                 </Link>
@@ -330,7 +330,7 @@ export default function IRSArrendamento2026Page() {
               <p className="text-gray-600 text-sm mb-4">
                 Coeficiente INE 2,24% e regras NRAU para aumentos de renda.
               </p>
-              <span className="text-blue-600 text-sm font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-sm font-medium">Ler artigo →</span>
             </Link>
             <Link href="/blog/recibos-renda-eletronicos-guia-2026" className="border border-gray-200 rounded-xl p-6 hover:shadow-lg transition block">
               <h3 className="font-semibold text-gray-900 mb-2">
@@ -339,7 +339,7 @@ export default function IRSArrendamento2026Page() {
               <p className="text-gray-600 text-sm mb-4">
                 Como emitir recibos eletrónicos no Portal das Finanças, prazos e coimas.
               </p>
-              <span className="text-blue-600 text-sm font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-sm font-medium">Ler artigo →</span>
             </Link>
           </div>
         </section>

--- a/src/app/blog/irs-senhorios-2026-guia-definitivo/page.tsx
+++ b/src/app/blog/irs-senhorios-2026-guia-definitivo/page.tsx
@@ -106,7 +106,7 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
           {/* Article Header */}
           <header className="mb-8">
             <div className="flex flex-wrap gap-2 mb-4">
-              <span className="px-3 py-1 bg-blue-100 text-blue-700 text-sm rounded-full font-medium">
+              <span className="px-3 py-1 bg-brand-100 text-brand-700 text-sm rounded-full font-medium">
                 IRS 2026
               </span>
               <span className="px-3 py-1 bg-green-100 text-green-700 text-sm rounded-full font-medium">
@@ -129,7 +129,7 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
               Nova taxa 10% para rendas moderadas, regime RSAA 0%, e guia completo do Anexo F passo a passo.
             </p>
 
-            <div className="flex items-center gap-4 text-sm text-gray-500 border-l-4 border-blue-500 pl-4">
+            <div className="flex items-center gap-4 text-sm text-gray-500 border-l-4 border-brand-500 pl-4">
               <time dateTime="2026-03-28T12:00:00.000Z">
                 28 de março de 2026
               </time>
@@ -141,7 +141,7 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
           </header>
 
           {/* Savings Calculator CTA */}
-          <div className="not-prose bg-gradient-to-r from-green-50 to-blue-50 border border-green-200 rounded-xl p-6 mb-8">
+          <div className="not-prose bg-gradient-to-r from-green-50 to-brand-50 border border-green-200 rounded-xl p-6 mb-8">
             <div className="flex items-start gap-4">
               <div className="flex-shrink-0">
                 <div className="w-12 h-12 bg-green-500 rounded-lg flex items-center justify-center">
@@ -165,7 +165,7 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
                   </Link>
                   <Link
                     href="/calculadora-aimi"
-                    className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition"
+                    className="inline-flex items-center px-4 py-2 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 transition"
                   >
                     🏠 Calculadora AIMI →
                   </Link>
@@ -179,18 +179,18 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
             <h3 className="text-lg font-semibold text-gray-900 mb-4">📋 Índice Completo</h3>
             <div className="grid md:grid-cols-2 gap-4">
               <ol className="space-y-2 text-sm">
-                <li><a href="#revolucao-fiscal-2026" className="text-blue-600 hover:text-blue-800">1. Revolução Fiscal 2026</a></li>
-                <li><a href="#taxa-10-porcento" className="text-blue-600 hover:text-blue-800">2. Nova Taxa 10% (≤€2.300/mês)</a></li>
-                <li><a href="#regime-rsaa" className="text-blue-600 hover:text-blue-800">3. Regime RSAA 0%</a></li>
-                <li><a href="#comparacao-regimes" className="text-blue-600 hover:text-blue-800">4. Comparação dos 4 Regimes</a></li>
-                <li><a href="#anexo-f-passo-a-passo" className="text-blue-600 hover:text-blue-800">5. Anexo F: Guia Passo a Passo</a></li>
+                <li><a href="#revolucao-fiscal-2026" className="text-brand-600 hover:text-brand-800">1. Revolução Fiscal 2026</a></li>
+                <li><a href="#taxa-10-porcento" className="text-brand-600 hover:text-brand-800">2. Nova Taxa 10% (≤€2.300/mês)</a></li>
+                <li><a href="#regime-rsaa" className="text-brand-600 hover:text-brand-800">3. Regime RSAA 0%</a></li>
+                <li><a href="#comparacao-regimes" className="text-brand-600 hover:text-brand-800">4. Comparação dos 4 Regimes</a></li>
+                <li><a href="#anexo-f-passo-a-passo" className="text-brand-600 hover:text-brand-800">5. Anexo F: Guia Passo a Passo</a></li>
               </ol>
               <ol start={6} className="space-y-2 text-sm">
-                <li><a href="#simulacoes-praticas" className="text-blue-600 hover:text-blue-800">6. Simulações Práticas</a></li>
-                <li><a href="#estrategias-otimizacao" className="text-blue-600 hover:text-blue-800">7. Estratégias de Otimização</a></li>
-                <li><a href="#senhorios-nao-residentes" className="text-blue-600 hover:text-blue-800">8. Senhorios Não-Residentes</a></li>
-                <li><a href="#prazos-documentos" className="text-blue-600 hover:text-blue-800">9. Prazos e Documentos</a></li>
-                <li><a href="#erros-comuns" className="text-blue-600 hover:text-blue-800">10. Erros Mais Comuns</a></li>
+                <li><a href="#simulacoes-praticas" className="text-brand-600 hover:text-brand-800">6. Simulações Práticas</a></li>
+                <li><a href="#estrategias-otimizacao" className="text-brand-600 hover:text-brand-800">7. Estratégias de Otimização</a></li>
+                <li><a href="#senhorios-nao-residentes" className="text-brand-600 hover:text-brand-800">8. Senhorios Não-Residentes</a></li>
+                <li><a href="#prazos-documentos" className="text-brand-600 hover:text-brand-800">9. Prazos e Documentos</a></li>
+                <li><a href="#erros-comuns" className="text-brand-600 hover:text-brand-800">10. Erros Mais Comuns</a></li>
               </ol>
             </div>
           </nav>
@@ -251,12 +251,12 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
                   <tr>
                     <td className="px-4 py-4 text-sm text-gray-900 font-medium">Dedução de Despesas</td>
                     <td className="px-4 py-4 text-sm text-gray-600">❌ Não permitido</td>
-                    <td className="px-4 py-4 text-sm text-blue-600">Simplicidade máxima</td>
+                    <td className="px-4 py-4 text-sm text-brand-600">Simplicidade máxima</td>
                   </tr>
                   <tr>
                     <td className="px-4 py-4 text-sm text-gray-900 font-medium">Agregação Familiar</td>
                     <td className="px-4 py-4 text-sm text-gray-600">✅ Opcional</td>
-                    <td className="px-4 py-4 text-sm text-blue-600">Flexibilidade total</td>
+                    <td className="px-4 py-4 text-sm text-brand-600">Flexibilidade total</td>
                   </tr>
                   <tr>
                     <td className="px-4 py-4 text-sm text-gray-900 font-medium">Complexidade</td>
@@ -300,9 +300,9 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
             <h3>🏠 Critérios para RSAA 0%</h3>
 
             <div className="not-prose grid md:grid-cols-2 gap-6 mb-6">
-              <div className="bg-blue-50 border border-blue-200 rounded-xl p-6">
-                <h4 className="text-blue-900 font-semibold mb-3">✅ Requisitos de Elegibilidade</h4>
-                <ul className="text-blue-800 space-y-2 text-sm">
+              <div className="bg-brand-50 border border-brand-200 rounded-xl p-6">
+                <h4 className="text-brand-900 font-semibold mb-3">✅ Requisitos de Elegibilidade</h4>
+                <ul className="text-brand-800 space-y-2 text-sm">
                   <li>• Renda ≤80% valor médio da zona</li>
                   <li>• Contrato mínimo 5 anos</li>
                   <li>• Certificação energética ≥C</li>
@@ -348,9 +348,9 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
                     <td className="px-3 py-4 text-sm text-gray-600">Habitação acessível</td>
                     <td className="px-3 py-4 text-sm text-green-600">🟢 Baixa</td>
                   </tr>
-                  <tr className="bg-blue-25">
-                    <td className="px-3 py-4 text-sm font-medium text-blue-900">Taxa 10%</td>
-                    <td className="px-3 py-4 text-sm text-blue-700">10%</td>
+                  <tr className="bg-brand-50">
+                    <td className="px-3 py-4 text-sm font-medium text-brand-900">Taxa 10%</td>
+                    <td className="px-3 py-4 text-sm text-brand-700">10%</td>
                     <td className="px-3 py-4 text-sm text-gray-600">❌ Não</td>
                     <td className="px-3 py-4 text-sm text-gray-600">Rendas ≤€2.300, poucas despesas</td>
                     <td className="px-3 py-4 text-sm text-green-600">🟢 Baixa</td>
@@ -380,16 +380,16 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
               Seguindo este guia, consegue preencher corretamente e maximizar as suas deduções.
             </p>
 
-            <div className="not-prose bg-blue-50 border border-blue-200 rounded-xl p-6 mb-6">
-              <h4 className="text-blue-900 font-semibold mb-3">📋 Documentos Necessários para o Anexo F</h4>
+            <div className="not-prose bg-brand-50 border border-brand-200 rounded-xl p-6 mb-6">
+              <h4 className="text-brand-900 font-semibold mb-3">📋 Documentos Necessários para o Anexo F</h4>
               <div className="grid md:grid-cols-2 gap-4">
-                <ul className="text-blue-800 space-y-2 text-sm">
+                <ul className="text-brand-800 space-y-2 text-sm">
                   <li>• ✅ Recibos de renda (todos os meses)</li>
                   <li>• ✅ Faturas de obras e reparações</li>
                   <li>• ✅ Seguros da propriedade</li>
                   <li>• ✅ Comissões de mediação</li>
                 </ul>
-                <ul className="text-blue-800 space-y-2 text-sm">
+                <ul className="text-brand-800 space-y-2 text-sm">
                   <li>• ✅ Juros de empréstimos habitação</li>
                   <li>• ✅ IMI pago</li>
                   <li>• ✅ Taxas municipais</li>
@@ -459,8 +459,8 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
 
             <div className="not-prose space-y-8 mb-8">
               {/* Simulação 1 */}
-              <div className="bg-gradient-to-r from-blue-50 to-purple-50 border border-blue-200 rounded-xl p-6">
-                <h4 className="text-blue-900 font-bold mb-4">💰 Simulação 1: T1 em Lisboa - Poupança €1.080/ano</h4>
+              <div className="bg-gradient-to-r from-brand-50 to-purple-50 border border-brand-200 rounded-xl p-6">
+                <h4 className="text-brand-900 font-bold mb-4">💰 Simulação 1: T1 em Lisboa - Poupança €1.080/ano</h4>
                 <div className="grid md:grid-cols-3 gap-6">
                   <div>
                     <h5 className="font-semibold text-gray-900 mb-2">📊 Dados</h5>
@@ -476,7 +476,7 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
                     <ul className="space-y-1 text-sm">
                       <li>• Taxa 25%: <span className="text-red-600 font-medium">€1.950</span></li>
                       <li>• Taxa 10%: <span className="text-green-600 font-medium">€780</span></li>
-                      <li>• Englobamento: <span className="text-blue-600">€1.088</span></li>
+                      <li>• Englobamento: <span className="text-brand-600">€1.088</span></li>
                     </ul>
                   </div>
                   <div className="bg-white rounded-lg p-4 border border-green-200">
@@ -492,7 +492,7 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
               </div>
 
               {/* Simulação 2 */}
-              <div className="bg-gradient-to-r from-green-50 to-blue-50 border border-green-200 rounded-xl p-6">
+              <div className="bg-gradient-to-r from-green-50 to-brand-50 border border-green-200 rounded-xl p-6">
                 <h4 className="text-green-900 font-bold mb-4">🏡 Simulação 2: T3 Porto c/ Empréstimo - Poupança €2.340/ano</h4>
                 <div className="grid md:grid-cols-3 gap-6">
                   <div>
@@ -631,9 +631,9 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
                   <li>• <strong>Mensal:</strong> Recibos eletrónicos (até dia 10)</li>
                 </ul>
               </div>
-              <div className="bg-blue-50 border border-blue-200 rounded-xl p-6">
-                <h4 className="text-blue-900 font-semibold mb-3">📋 Checklist Documentos</h4>
-                <ul className="text-blue-800 space-y-2 text-sm">
+              <div className="bg-brand-50 border border-brand-200 rounded-xl p-6">
+                <h4 className="text-brand-900 font-semibold mb-3">📋 Checklist Documentos</h4>
+                <ul className="text-brand-800 space-y-2 text-sm">
                   <li>• ✅ Recibos renda (12 meses)</li>
                   <li>• ✅ Faturas despesas dedutíveis</li>
                   <li>• ✅ Extratos bancários empréstimos</li>
@@ -731,7 +731,7 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
                 }
               ].map((item, index) => (
                 <details key={index} className="border border-gray-200 rounded-xl p-6">
-                  <summary className="font-semibold text-gray-900 cursor-pointer hover:text-blue-600 transition">
+                  <summary className="font-semibold text-gray-900 cursor-pointer hover:text-brand-600 transition">
                     {item.pergunta}
                   </summary>
                   <p className="text-gray-600 mt-3 text-sm leading-relaxed">
@@ -742,7 +742,7 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
             </div>
 
             {/* Final CTA */}
-            <div className="not-prose mt-12 bg-gradient-to-r from-green-500 to-blue-600 rounded-xl p-8 text-white text-center">
+            <div className="not-prose mt-12 bg-gradient-to-r from-green-500 to-brand-600 rounded-xl p-8 text-white text-center">
               <h3 className="text-2xl font-bold mb-4">
                 💡 Maximize as Suas Poupanças Fiscais Agora
               </h3>
@@ -759,7 +759,7 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
                 </Link>
                 <Link
                   href="/#waitlist"
-                  className="px-6 py-3 border border-white text-white rounded-lg font-medium hover:bg-white hover:text-blue-600 transition"
+                  className="px-6 py-3 border border-white text-white rounded-lg font-medium hover:bg-white hover:text-brand-600 transition"
                 >
                   📧 Alertas Fiscais Gratuitos
                 </Link>
@@ -779,16 +779,16 @@ export default function IRSSenhorios2026GuiaDefinitivo() {
               <p className="text-gray-600 text-sm mb-4">
                 Coeficiente INE 2,24% e regras NRAU para aumentos legais de renda.
               </p>
-              <span className="text-blue-600 text-sm font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-sm font-medium">Ler artigo →</span>
             </Link>
-            <Link href="/calculadora" className="border border-gray-200 rounded-xl p-6 hover:shadow-lg transition block bg-blue-50">
-              <h3 className="font-semibold text-blue-900 mb-2">
+            <Link href="/calculadora" className="border border-gray-200 rounded-xl p-6 hover:shadow-lg transition block bg-brand-50">
+              <h3 className="font-semibold text-brand-900 mb-2">
                 🧮 Simulador IRS Senhorios 2026
               </h3>
-              <p className="text-blue-700 text-sm mb-4">
+              <p className="text-brand-700 text-sm mb-4">
                 Compare os 4 regimes fiscais e descubra a sua poupança exata.
               </p>
-              <span className="text-blue-600 text-sm font-medium">Usar simulador →</span>
+              <span className="text-brand-600 text-sm font-medium">Usar simulador →</span>
             </Link>
             <Link href="/calculadora-aimi" className="border border-gray-200 rounded-xl p-6 hover:shadow-lg transition block bg-green-50">
               <h3 className="font-semibold text-green-900 mb-2">

--- a/src/app/blog/isencao-aimi-2026-qualificar-nova-isencao/page.tsx
+++ b/src/app/blog/isencao-aimi-2026-qualificar-nova-isencao/page.tsx
@@ -36,7 +36,7 @@ export default function AIMIExemptionBlogPost() {
           </Link>
           <div className="mt-4">
             <div className="flex flex-wrap gap-2 mb-3">
-              <span className="px-3 py-1 bg-blue-100 text-blue-700 text-sm font-medium rounded-full">
+              <span className="px-3 py-1 bg-brand-100 text-brand-700 text-sm font-medium rounded-full">
                 Isenção AIMI
               </span>
               <span className="px-3 py-1 bg-green-100 text-green-700 text-sm font-medium rounded-full">
@@ -65,9 +65,9 @@ export default function AIMIExemptionBlogPost() {
         <div className="prose prose-lg prose-gray max-w-none">
 
           {/* Introduction */}
-          <div className="bg-blue-50 border-l-4 border-blue-400 p-6 rounded-r-lg mb-8">
-            <p className="text-blue-800 font-medium mb-2">💡 Resumo Rápido</p>
-            <p className="text-blue-700">
+          <div className="bg-brand-50 border-l-4 border-brand-400 p-6 rounded-r-lg mb-8">
+            <p className="text-brand-800 font-medium mb-2">💡 Resumo Rápido</p>
+            <p className="text-brand-700">
               A partir de 2026, senhorios com rendas até <strong>€2.300 por mês por propriedade</strong> podem qualificar-se
               para isenção total do AIMI. Esta medida visa promover habitação acessível e pode poupar-lhe <strong>milhares de euros por ano</strong>.
             </p>
@@ -157,22 +157,22 @@ export default function AIMIExemptionBlogPost() {
             determina instantaneamente se qualifica para a isenção 2026.
           </p>
 
-          <div className="bg-blue-50 border border-blue-200 rounded-xl p-8 text-center my-8">
-            <h3 className="text-lg font-semibold text-blue-900 mb-4">
+          <div className="bg-brand-50 border border-brand-200 rounded-xl p-8 text-center my-8">
+            <h3 className="text-lg font-semibold text-brand-900 mb-4">
               🧮 Calculadora Isenção AIMI 2026
             </h3>
-            <p className="text-blue-700 mb-6">
+            <p className="text-brand-700 mb-6">
               Introduza os dados das suas propriedades e descubra se qualifica para a isenção.
               Cálculo instantâneo com estimativa de poupanças anuais.
             </p>
             <div className="space-y-3">
               <Link
                 href="/aimi"
-                className="inline-block px-8 py-4 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition"
+                className="inline-block px-8 py-4 bg-brand-600 text-white font-semibold rounded-lg hover:bg-brand-700 transition"
               >
                 Verificar Elegibilidade AIMI →
               </Link>
-              <p className="text-blue-600 text-sm">Disponível em Português e Inglês • 100% Gratuito</p>
+              <p className="text-brand-600 text-sm">Disponível em Português e Inglês • 100% Gratuito</p>
             </div>
           </div>
 
@@ -282,14 +282,14 @@ export default function AIMIExemptionBlogPost() {
             <strong>Próximos Passos:</strong>
           </p>
           <ol className="ml-6 space-y-2 my-4">
-            <li>1. Use a nossa <Link href="/aimi" className="text-blue-600 hover:text-blue-700 font-medium">calculadora AIMI</Link> para verificar elegibilidade</li>
+            <li>1. Use a nossa <Link href="/aimi" className="text-brand-600 hover:text-brand-700 font-medium">calculadora AIMI</Link> para verificar elegibilidade</li>
             <li>2. Ajuste rendas se necessário (antes do prazo de março)</li>
             <li>3. Prepare e submeta a documentação exigida</li>
             <li>4. Mantenha-se atualizado com mudanças legislativas</li>
           </ol>
 
           {/* CTA Section */}
-          <div className="bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-200 rounded-xl p-8 text-center mt-12">
+          <div className="bg-gradient-to-r from-brand-50 to-brand-50 border border-brand-200 rounded-xl p-8 text-center mt-12">
             <h3 className="text-2xl font-bold text-gray-900 mb-4">
               Simplifique a Gestão do Seu Portfólio
             </h3>
@@ -300,13 +300,13 @@ export default function AIMIExemptionBlogPost() {
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link
                 href="/calculadora"
-                className="px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition"
+                className="px-6 py-3 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 transition"
               >
                 Simulador Fiscal Completo
               </Link>
               <Link
                 href="/calculadora-rendas"
-                className="px-6 py-3 border border-blue-300 text-blue-700 rounded-lg font-medium hover:bg-blue-50 transition"
+                className="px-6 py-3 border border-brand-300 text-brand-700 rounded-lg font-medium hover:bg-brand-50 transition"
               >
                 Calculadora de Rendas 2026
               </Link>

--- a/src/app/blog/portugal-expat-landlord-compliance-guide-2026/page.tsx
+++ b/src/app/blog/portugal-expat-landlord-compliance-guide-2026/page.tsx
@@ -28,7 +28,7 @@ export default function Page() {
       <article className="max-w-4xl mx-auto px-6 py-12">
         <header className="mb-8">
           <div className="flex flex-wrap gap-2 mb-4">
-            <span className="px-3 py-1 bg-blue-100 text-blue-700 text-sm rounded">Expat Guide</span>
+            <span className="px-3 py-1 bg-brand-100 text-brand-700 text-sm rounded">Expat Guide</span>
             <span className="px-3 py-1 bg-green-100 text-green-700 text-sm rounded">2026 Tax Rules</span>
             <span className="px-3 py-1 bg-purple-100 text-purple-700 text-sm rounded">Compliance</span>
             <span className="px-3 py-1 bg-orange-100 text-orange-700 text-sm rounded">Legal Requirements</span>
@@ -56,12 +56,12 @@ export default function Page() {
           <div className="bg-gray-50 border border-gray-200 rounded-xl p-6 mb-8">
             <h2 className="text-lg font-semibold text-gray-900 mb-4">Quick Navigation</h2>
             <ul className="space-y-2 text-sm">
-              <li><a href="#tax-obligations" className="text-blue-600 hover:text-blue-700">Tax Obligations for Non-Residents</a></li>
-              <li><a href="#rental-receipts" className="text-blue-600 hover:text-blue-700">Rental Receipt Requirements</a></li>
-              <li><a href="#aimi-exemptions" className="text-blue-600 hover:text-blue-700">AIMI Exemptions for Expats</a></li>
-              <li><a href="#fiscal-representation" className="text-blue-600 hover:text-blue-700">Fiscal Representation Requirements</a></li>
-              <li><a href="#compliance-checklist" className="text-blue-600 hover:text-blue-700">Annual Compliance Checklist</a></li>
-              <li><a href="#common-mistakes" className="text-blue-600 hover:text-blue-700">Common Compliance Mistakes</a></li>
+              <li><a href="#tax-obligations" className="text-brand-600 hover:text-brand-700">Tax Obligations for Non-Residents</a></li>
+              <li><a href="#rental-receipts" className="text-brand-600 hover:text-brand-700">Rental Receipt Requirements</a></li>
+              <li><a href="#aimi-exemptions" className="text-brand-600 hover:text-brand-700">AIMI Exemptions for Expats</a></li>
+              <li><a href="#fiscal-representation" className="text-brand-600 hover:text-brand-700">Fiscal Representation Requirements</a></li>
+              <li><a href="#compliance-checklist" className="text-brand-600 hover:text-brand-700">Annual Compliance Checklist</a></li>
+              <li><a href="#common-mistakes" className="text-brand-600 hover:text-brand-700">Common Compliance Mistakes</a></li>
             </ul>
           </div>
 
@@ -70,9 +70,9 @@ export default function Page() {
             As an expat landlord in Portugal, you face unique compliance challenges that Portuguese residents don't encounter. Language barriers, unfamiliar tax systems, and complex legal requirements can make property management feel overwhelming. This comprehensive guide covers everything you need to know about staying compliant as a non-resident property owner in Portugal for 2026.
           </p>
 
-          <div className="bg-blue-50 border-l-4 border-blue-400 p-6 mb-8">
-            <h3 className="text-lg font-semibold text-blue-900 mb-3">🎯 Key Changes for 2026</h3>
-            <ul className="space-y-2 text-blue-800">
+          <div className="bg-brand-50 border-l-4 border-brand-400 p-6 mb-8">
+            <h3 className="text-lg font-semibold text-brand-900 mb-3">🎯 Key Changes for 2026</h3>
+            <ul className="space-y-2 text-brand-800">
               <li><strong>New 10% Tax Rate:</strong> Simplified taxation option for rental income</li>
               <li><strong>AIMI Exemptions Expanded:</strong> More properties qualify for affordable housing exemptions</li>
               <li><strong>Digital Receipts Mandatory:</strong> All rental receipts must be issued electronically</li>
@@ -211,7 +211,7 @@ export default function Page() {
                   <li><strong>€800K property:</strong> Save €2,250/year in AIMI</li>
                   <li><strong>€1M property:</strong> Save €3,000/year in AIMI</li>
                 </ul>
-                <Link href="/calculadora-aimi" className="inline-block mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-700 transition">
+                <Link href="/calculadora-aimi" className="inline-block mt-4 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-brand-700 transition">
                   Check AIMI Exemption →
                 </Link>
               </div>
@@ -256,9 +256,9 @@ export default function Page() {
 
             <h3 className="text-2xl font-semibold text-gray-900 mb-4">Choosing a Fiscal Representative</h3>
 
-            <div className="bg-blue-50 border border-blue-200 rounded-xl p-6 mb-8">
-              <h4 className="text-lg font-semibold text-blue-900 mb-3">Selection Criteria</h4>
-              <ul className="space-y-2 text-blue-800">
+            <div className="bg-brand-50 border border-brand-200 rounded-xl p-6 mb-8">
+              <h4 className="text-lg font-semibold text-brand-900 mb-3">Selection Criteria</h4>
+              <ul className="space-y-2 text-brand-800">
                 <li><strong>Professional qualifications:</strong> Certified accountant or tax lawyer</li>
                 <li><strong>English proficiency:</strong> Clear communication in your language</li>
                 <li><strong>Property experience:</strong> Specialization in real estate taxation</li>
@@ -367,7 +367,7 @@ export default function Page() {
               Managing rental properties in Portugal as an expat doesn't have to be overwhelming. Our platform helps you calculate the optimal tax regime, check AIMI exemptions, and stay compliant with Portuguese regulations.
             </p>
             <div className="space-y-4">
-              <Link href="/calculadora" className="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition mr-4">
+              <Link href="/calculadora" className="inline-block bg-brand-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-brand-700 transition mr-4">
                 Calculate Your Taxes →
               </Link>
               <Link href="/calculadora-aimi" className="inline-block bg-green-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-green-700 transition">

--- a/src/app/blog/portugal-landlord-tax-calculator-2026/page.tsx
+++ b/src/app/blog/portugal-landlord-tax-calculator-2026/page.tsx
@@ -44,7 +44,7 @@ export default function PortugalLandlordTaxCalculator2026Page() {
           {/* Article Header */}
           <header className="mb-8">
             <div className="flex flex-wrap gap-2 mb-4">
-              <span className="px-3 py-1 bg-blue-100 text-blue-700 text-sm rounded-full font-medium">
+              <span className="px-3 py-1 bg-brand-100 text-brand-700 text-sm rounded-full font-medium">
                 English Guide
               </span>
               <span className="px-3 py-1 bg-green-100 text-green-700 text-sm rounded-full font-medium">
@@ -68,7 +68,7 @@ export default function PortugalLandlordTaxCalculator2026Page() {
               property investors with practical examples and English-language support.
             </p>
 
-            <div className="flex items-center gap-4 text-sm text-gray-500 border-l-4 border-blue-500 pl-4">
+            <div className="flex items-center gap-4 text-sm text-gray-500 border-l-4 border-brand-500 pl-4">
               <time dateTime="2026-03-22T14:00:00.000Z">
                 March 22, 2026
               </time>
@@ -80,16 +80,16 @@ export default function PortugalLandlordTaxCalculator2026Page() {
           {/* Content */}
           <div className="prose prose-gray prose-lg max-w-none">
             {/* Quick Calculator CTA */}
-            <div className="not-prose bg-blue-50 border border-blue-200 rounded-xl p-6 mb-8">
-              <h3 className="text-lg font-semibold text-blue-900 mb-2">
+            <div className="not-prose bg-brand-50 border border-brand-200 rounded-xl p-6 mb-8">
+              <h3 className="text-lg font-semibold text-brand-900 mb-2">
                 🧮 Calculate Your Portugal Tax Now
               </h3>
-              <p className="text-blue-700 mb-4">
+              <p className="text-brand-700 mb-4">
                 Use our free bilingual calculator to compare all tax regimes and find the best option for your Portuguese rental properties.
               </p>
               <Link
                 href="/calculadora"
-                className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition"
+                className="inline-flex items-center px-4 py-2 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 transition"
               >
                 Open Free Tax Calculator →
               </Link>
@@ -99,13 +99,13 @@ export default function PortugalLandlordTaxCalculator2026Page() {
             <nav className="not-prose bg-gray-50 rounded-xl p-6 mb-8">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Table of Contents</h3>
               <ol className="space-y-2 text-sm">
-                <li><a href="#overview-2026" className="text-blue-600 hover:text-blue-800">1. Portugal Landlord Tax Overview 2026</a></li>
-                <li><a href="#new-10-percent-rate" className="text-blue-600 hover:text-blue-800">2. New 10% Fixed Tax Rate</a></li>
-                <li><a href="#four-tax-regimes" className="text-blue-600 hover:text-blue-800">3. All 4 Tax Regimes Explained</a></li>
-                <li><a href="#expat-considerations" className="text-blue-600 hover:text-blue-800">4. Special Rules for Expats & Non-Residents</a></li>
-                <li><a href="#calculator-examples" className="text-blue-600 hover:text-blue-800">5. Practical Calculator Examples</a></li>
-                <li><a href="#deadlines-compliance" className="text-blue-600 hover:text-blue-800">6. Tax Deadlines & Compliance</a></li>
-                <li><a href="#common-mistakes" className="text-blue-600 hover:text-blue-800">7. Common Mistakes to Avoid</a></li>
+                <li><a href="#overview-2026" className="text-brand-600 hover:text-brand-800">1. Portugal Landlord Tax Overview 2026</a></li>
+                <li><a href="#new-10-percent-rate" className="text-brand-600 hover:text-brand-800">2. New 10% Fixed Tax Rate</a></li>
+                <li><a href="#four-tax-regimes" className="text-brand-600 hover:text-brand-800">3. All 4 Tax Regimes Explained</a></li>
+                <li><a href="#expat-considerations" className="text-brand-600 hover:text-brand-800">4. Special Rules for Expats & Non-Residents</a></li>
+                <li><a href="#calculator-examples" className="text-brand-600 hover:text-brand-800">5. Practical Calculator Examples</a></li>
+                <li><a href="#deadlines-compliance" className="text-brand-600 hover:text-brand-800">6. Tax Deadlines & Compliance</a></li>
+                <li><a href="#common-mistakes" className="text-brand-600 hover:text-brand-800">7. Common Mistakes to Avoid</a></li>
               </ol>
             </nav>
 
@@ -306,7 +306,7 @@ export default function PortugalLandlordTaxCalculator2026Page() {
                   </div>
                   <div>
                     <p><strong>Best Option: Progressive Rates</strong></p>
-                    <ul className="text-blue-600 space-y-1">
+                    <ul className="text-brand-600 space-y-1">
                       <li>• Taxable income: €15,000 (after deductions)</li>
                       <li>• Tax liability: ~€2,175 (14.5% rate)</li>
                       <li>• Net income: €21,825</li>
@@ -332,7 +332,7 @@ export default function PortugalLandlordTaxCalculator2026Page() {
                   </div>
                   <div>
                     <p><strong>Best Option: Progressive Rates</strong></p>
-                    <ul className="text-blue-600 space-y-1">
+                    <ul className="text-brand-600 space-y-1">
                       <li>• Taxable income: €36,000</li>
                       <li>• Tax liability: ~€8,640 (24% avg rate)</li>
                       <li>• Net income: €45,360</li>
@@ -358,9 +358,9 @@ export default function PortugalLandlordTaxCalculator2026Page() {
                   </ul>
                 </div>
 
-                <div className="bg-blue-50 border border-blue-200 rounded-xl p-6">
-                  <h4 className="text-blue-900 font-semibold mb-3">📋 Required Documentation</h4>
-                  <ul className="text-blue-800 space-y-2 text-sm">
+                <div className="bg-brand-50 border border-brand-200 rounded-xl p-6">
+                  <h4 className="text-brand-900 font-semibold mb-3">📋 Required Documentation</h4>
+                  <ul className="text-brand-800 space-y-2 text-sm">
                     <li>• Rental receipts and contracts</li>
                     <li>• Property registration documents</li>
                     <li>• Expense invoices (if claiming deductions)</li>
@@ -395,24 +395,24 @@ export default function PortugalLandlordTaxCalculator2026Page() {
               <li>First-time compliance setup</li>
             </ul>
 
-            <div className="not-prose mt-12 bg-gradient-to-r from-blue-500 to-purple-600 rounded-xl p-8 text-white text-center">
+            <div className="not-prose mt-12 bg-gradient-to-r from-brand-500 to-purple-600 rounded-xl p-8 text-white text-center">
               <h3 className="text-xl font-bold mb-4">
                 Simplify Your Portugal Tax Compliance
               </h3>
-              <p className="mb-6 text-blue-100">
+              <p className="mb-6 text-brand-100">
                 Senhorio provides bilingual tools designed for expat and non-resident landlords.
                 Calculate, compare, and optimize your Portuguese rental income taxes automatically.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <Link
                   href="/calculadora"
-                  className="px-6 py-3 bg-white text-blue-600 rounded-lg font-medium hover:bg-gray-100 transition"
+                  className="px-6 py-3 bg-white text-brand-600 rounded-lg font-medium hover:bg-gray-100 transition"
                 >
                   Use Free Tax Calculator
                 </Link>
                 <Link
                   href="/aimi"
-                  className="px-6 py-3 border border-white text-white rounded-lg font-medium hover:bg-white hover:text-blue-600 transition"
+                  className="px-6 py-3 border border-white text-white rounded-lg font-medium hover:bg-white hover:text-brand-600 transition"
                 >
                   Check AIMI Exemption
                 </Link>
@@ -432,7 +432,7 @@ export default function PortugalLandlordTaxCalculator2026Page() {
               <p className="text-gray-600 text-sm mb-4">
                 Complete guide to the new 10% tax rate in Portuguese for local landlords.
               </p>
-              <span className="text-blue-600 text-sm font-medium">Read article →</span>
+              <span className="text-brand-600 text-sm font-medium">Read article →</span>
             </Link>
             <Link href="/blog/isencao-aimi-2026-qualificar-nova-isencao" className="border border-gray-200 rounded-xl p-6 hover:shadow-lg transition block">
               <h3 className="font-semibold text-gray-900 mb-2">
@@ -441,7 +441,7 @@ export default function PortugalLandlordTaxCalculator2026Page() {
               <p className="text-gray-600 text-sm mb-4">
                 How to qualify for the AIMI tax exemption with rentals under €2,300/month.
               </p>
-              <span className="text-blue-600 text-sm font-medium">Read article →</span>
+              <span className="text-brand-600 text-sm font-medium">Read article →</span>
             </Link>
           </div>
         </section>

--- a/src/app/blog/portugal-rental-property-tax-guide-2026/page.tsx
+++ b/src/app/blog/portugal-rental-property-tax-guide-2026/page.tsx
@@ -45,11 +45,11 @@ export default function PortugalRentalPropertyTaxGuide() {
         <div className="prose prose-lg prose-gray max-w-none">
 
           {/* Introduction */}
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold text-blue-900 mb-3 mt-0">
+          <div className="bg-brand-50 border border-brand-200 rounded-lg p-6 mb-8">
+            <h2 className="text-xl font-bold text-brand-900 mb-3 mt-0">
               🇵🇹 2026 Tax Changes Summary
             </h2>
-            <ul className="text-blue-800 mb-0">
+            <ul className="text-brand-800 mb-0">
               <li><strong>New 10% tax option</strong> for rental income (replaces complex calculations)</li>
               <li><strong>AIMI exemption</strong> for affordable rental properties (≤€2,300/month)</li>
               <li><strong>Rent increase cap</strong> of 2.24% for 2026 (INE coefficient)</li>
@@ -130,14 +130,14 @@ export default function PortugalRentalPropertyTaxGuide() {
           <h3>Potential Savings</h3>
           <p>AIMI is calculated at 0.4% of property's patrimonial value for individuals. For a property valued at €300,000, AIMI would normally be €1,200 annually. The exemption eliminates this cost entirely for qualifying properties.</p>
 
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 my-8">
-            <h3 className="text-blue-900 mt-0">🔍 Check Your AIMI Eligibility</h3>
-            <p className="text-blue-800 mb-4">
+          <div className="bg-brand-50 border border-brand-200 rounded-lg p-6 my-8">
+            <h3 className="text-brand-900 mt-0">🔍 Check Your AIMI Eligibility</h3>
+            <p className="text-brand-800 mb-4">
               Our AIMI exemption calculator helps you determine if your rental properties qualify for the 2026 exemption and estimates your potential savings.
             </p>
             <Link
               href="/aimi"
-              className="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition"
+              className="inline-block bg-brand-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-brand-700 transition"
             >
               Check AIMI Exemption →
             </Link>
@@ -301,7 +301,7 @@ export default function PortugalRentalPropertyTaxGuide() {
           </ul>
 
           {/* CTA Section */}
-          <div className="bg-gradient-to-r from-blue-50 to-green-50 border border-blue-200 rounded-xl p-8 my-12 text-center">
+          <div className="bg-gradient-to-r from-brand-50 to-green-50 border border-brand-200 rounded-xl p-8 my-12 text-center">
             <h3 className="text-2xl font-bold text-gray-900 mb-4">
               Simplify Your Rental Property Taxes
             </h3>
@@ -313,7 +313,7 @@ export default function PortugalRentalPropertyTaxGuide() {
             <div className="flex flex-col sm:flex-row gap-4 justify-center max-w-2xl mx-auto">
               <Link
                 href="/calculadora"
-                className="px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition"
+                className="px-6 py-3 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 transition"
               >
                 🧮 Tax Calculator
               </Link>
@@ -346,9 +346,9 @@ export default function PortugalRentalPropertyTaxGuide() {
             </p>
             <p className="mt-4">
               <strong>Last updated:</strong> March 22, 2026 |
-              <strong> Related tools:</strong> <Link href="/calculadora" className="text-blue-600 hover:text-blue-700">Tax Calculator</Link>,
-              <Link href="/aimi" className="text-blue-600 hover:text-blue-700"> AIMI Exemption Checker</Link>,
-              <Link href="/calculadora-rendas" className="text-blue-600 hover:text-blue-700"> Rent Increase Calculator</Link>
+              <strong> Related tools:</strong> <Link href="/calculadora" className="text-brand-600 hover:text-brand-700">Tax Calculator</Link>,
+              <Link href="/aimi" className="text-brand-600 hover:text-brand-700"> AIMI Exemption Checker</Link>,
+              <Link href="/calculadora-rendas" className="text-brand-600 hover:text-brand-700"> Rent Increase Calculator</Link>
             </p>
           </div>
         </div>

--- a/src/app/blog/recibos-renda-eletronicos-guia-2026/page.tsx
+++ b/src/app/blog/recibos-renda-eletronicos-guia-2026/page.tsx
@@ -46,7 +46,7 @@ export default function RecibosRendaEletronicosPage() {
               <span className="px-3 py-1 bg-emerald-100 text-emerald-700 text-sm rounded-full font-medium">
                 Recibos Eletrónicos
               </span>
-              <span className="px-3 py-1 bg-blue-100 text-blue-700 text-sm rounded-full font-medium">
+              <span className="px-3 py-1 bg-brand-100 text-brand-700 text-sm rounded-full font-medium">
                 Portal Finanças
               </span>
               <span className="px-3 py-1 bg-purple-100 text-purple-700 text-sm rounded-full font-medium">
@@ -96,17 +96,17 @@ export default function RecibosRendaEletronicosPage() {
             <nav className="not-prose bg-gray-50 rounded-xl p-6 mb-8">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Índice</h3>
               <ol className="space-y-2 text-sm">
-                <li><a href="#obrigacao-legal" className="text-blue-600 hover:text-blue-800">1. Obrigação Legal: Quem Deve Emitir Recibos Eletrónicos</a></li>
-                <li><a href="#portal-financas" className="text-blue-600 hover:text-blue-800">2. Como Aceder ao Portal das Finanças</a></li>
-                <li><a href="#passo-a-passo" className="text-blue-600 hover:text-blue-800">3. Passo a Passo: Emitir um Recibo</a></li>
-                <li><a href="#campos-obrigatorios" className="text-blue-600 hover:text-blue-800">4. Campos Obrigatórios do Recibo</a></li>
-                <li><a href="#prazos-legais" className="text-blue-600 hover:text-blue-800">5. Prazos Legais para Emissão</a></li>
-                <li><a href="#coimas-penalizacoes" className="text-blue-600 hover:text-blue-800">6. Coimas e Penalizações</a></li>
-                <li><a href="#situacoes-especiais" className="text-blue-600 hover:text-blue-800">7. Situações Especiais</a></li>
-                <li><a href="#retificacao-anulacao" className="text-blue-600 hover:text-blue-800">8. Retificação e Anulação de Recibos</a></li>
-                <li><a href="#irs-declaracao" className="text-blue-600 hover:text-blue-800">9. Recibos e Declaração de IRS</a></li>
-                <li><a href="#automatizacao" className="text-blue-600 hover:text-blue-800">10. Automatização: O Futuro dos Recibos</a></li>
-                <li><a href="#faq" className="text-blue-600 hover:text-blue-800">11. Perguntas Frequentes</a></li>
+                <li><a href="#obrigacao-legal" className="text-brand-600 hover:text-brand-800">1. Obrigação Legal: Quem Deve Emitir Recibos Eletrónicos</a></li>
+                <li><a href="#portal-financas" className="text-brand-600 hover:text-brand-800">2. Como Aceder ao Portal das Finanças</a></li>
+                <li><a href="#passo-a-passo" className="text-brand-600 hover:text-brand-800">3. Passo a Passo: Emitir um Recibo</a></li>
+                <li><a href="#campos-obrigatorios" className="text-brand-600 hover:text-brand-800">4. Campos Obrigatórios do Recibo</a></li>
+                <li><a href="#prazos-legais" className="text-brand-600 hover:text-brand-800">5. Prazos Legais para Emissão</a></li>
+                <li><a href="#coimas-penalizacoes" className="text-brand-600 hover:text-brand-800">6. Coimas e Penalizações</a></li>
+                <li><a href="#situacoes-especiais" className="text-brand-600 hover:text-brand-800">7. Situações Especiais</a></li>
+                <li><a href="#retificacao-anulacao" className="text-brand-600 hover:text-brand-800">8. Retificação e Anulação de Recibos</a></li>
+                <li><a href="#irs-declaracao" className="text-brand-600 hover:text-brand-800">9. Recibos e Declaração de IRS</a></li>
+                <li><a href="#automatizacao" className="text-brand-600 hover:text-brand-800">10. Automatização: O Futuro dos Recibos</a></li>
+                <li><a href="#faq" className="text-brand-600 hover:text-brand-800">11. Perguntas Frequentes</a></li>
               </ol>
             </nav>
 
@@ -131,9 +131,9 @@ export default function RecibosRendaEletronicosPage() {
               <li>Cedência de uso de imóvel</li>
             </ul>
 
-            <div className="not-prose bg-blue-50 border border-blue-200 rounded-xl p-6 mb-6">
-              <h4 className="text-blue-900 font-semibold mb-2">💡 Quem está dispensado?</h4>
-              <ul className="text-blue-800 space-y-1 text-sm">
+            <div className="not-prose bg-brand-50 border border-brand-200 rounded-xl p-6 mb-6">
+              <h4 className="text-brand-900 font-semibold mb-2">💡 Quem está dispensado?</h4>
+              <ul className="text-brand-800 space-y-1 text-sm">
                 <li>• Senhorios com idade igual ou superior a <strong>65 anos</strong> que não disponham de acesso à internet (devem comunicar à AT)</li>
                 <li>• Senhorios com <strong>incapacidade reconhecida</strong> que impossibilite o uso de meios digitais</li>
                 <li>• Nestes casos, podem emitir recibos em papel, mas devem comunicar os rendimentos à AT por outros meios</li>
@@ -351,13 +351,13 @@ export default function RecibosRendaEletronicosPage() {
                 </p>
               </div>
 
-              <div className="bg-blue-50 border border-blue-200 rounded-xl p-6">
-                <h4 className="text-blue-900 font-semibold mb-3">Prazo para registo do contrato</h4>
-                <p className="text-blue-800 text-sm mb-2">
+              <div className="bg-brand-50 border border-brand-200 rounded-xl p-6">
+                <h4 className="text-brand-900 font-semibold mb-3">Prazo para registo do contrato</h4>
+                <p className="text-brand-800 text-sm mb-2">
                   O contrato de arrendamento deve ser comunicado à AT no prazo de <strong>30 dias</strong>
                   após a celebração.
                 </p>
-                <p className="text-blue-700 text-xs">
+                <p className="text-brand-700 text-xs">
                   O registo é pré-requisito para a emissão de recibos eletrónicos.
                 </p>
               </div>
@@ -665,24 +665,24 @@ export default function RecibosRendaEletronicosPage() {
               </details>
             </div>
 
-            <div className="not-prose mt-12 bg-gradient-to-r from-blue-500 to-purple-600 rounded-xl p-8 text-white text-center">
+            <div className="not-prose mt-12 bg-gradient-to-r from-brand-500 to-purple-600 rounded-xl p-8 text-white text-center">
               <h3 className="text-xl font-bold mb-4">
                 Simplifique a Gestão dos Seus Imóveis
               </h3>
-              <p className="mb-6 text-blue-100">
+              <p className="mb-6 text-brand-100">
                 O Senhorio é a plataforma que automatiza recibos, calcula impostos e gere
                 contratos para senhorios portugueses.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <Link
                   href="/#waitlist"
-                  className="px-6 py-3 bg-white text-blue-600 rounded-lg font-medium hover:bg-gray-100 transition"
+                  className="px-6 py-3 bg-white text-brand-600 rounded-lg font-medium hover:bg-gray-100 transition"
                 >
                   Entrar na Lista de Espera
                 </Link>
                 <Link
                   href="/calculadora"
-                  className="px-6 py-3 border border-white text-white rounded-lg font-medium hover:bg-white hover:text-blue-600 transition"
+                  className="px-6 py-3 border border-white text-white rounded-lg font-medium hover:bg-white hover:text-brand-600 transition"
                 >
                   Usar Calculadora IRS Gratuita
                 </Link>
@@ -702,7 +702,7 @@ export default function RecibosRendaEletronicosPage() {
               <p className="text-gray-600 text-sm mb-4">
                 Guia completo sobre a nova taxa fixa de 10% e comparação de regimes fiscais.
               </p>
-              <span className="text-blue-600 text-sm font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-sm font-medium">Ler artigo →</span>
             </Link>
             <Link href="/blog/como-calcular-atualizacoes-renda-2026" className="border border-gray-200 rounded-xl p-6 hover:shadow-lg transition block">
               <h3 className="font-semibold text-gray-900 mb-2">
@@ -711,7 +711,7 @@ export default function RecibosRendaEletronicosPage() {
               <p className="text-gray-600 text-sm mb-4">
                 Coeficiente INE 2,24%, regras NRAU e exemplos práticos de cálculo.
               </p>
-              <span className="text-blue-600 text-sm font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-sm font-medium">Ler artigo →</span>
             </Link>
           </div>
         </section>

--- a/src/app/blog/registo-contrato-arrendamento-at-2026/page.tsx
+++ b/src/app/blog/registo-contrato-arrendamento-at-2026/page.tsx
@@ -44,7 +44,7 @@ export default function RegistoContratoArrendamento2026Page() {
               <span className="px-3 py-1 bg-red-100 text-red-700 text-sm rounded-full font-medium">
                 Obrigação Legal
               </span>
-              <span className="px-3 py-1 bg-blue-100 text-blue-700 text-sm rounded-full font-medium">
+              <span className="px-3 py-1 bg-brand-100 text-brand-700 text-sm rounded-full font-medium">
                 Portal das Finanças
               </span>
               <span className="px-3 py-1 bg-green-100 text-green-700 text-sm rounded-full font-medium">
@@ -89,14 +89,14 @@ export default function RegistoContratoArrendamento2026Page() {
             <nav className="not-prose bg-gray-50 rounded-xl p-6 mb-8">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Índice</h3>
               <ol className="space-y-2 text-sm">
-                <li><a href="#obrigacao-legal" className="text-blue-600 hover:text-blue-800">1. Porquê é obrigatório registar?</a></li>
-                <li><a href="#o-que-registar" className="text-blue-600 hover:text-blue-800">2. O que tem de comunicar à AT</a></li>
-                <li><a href="#passo-a-passo" className="text-blue-600 hover:text-blue-800">3. Passo a passo no Portal das Finanças</a></li>
-                <li><a href="#documentos" className="text-blue-600 hover:text-blue-800">4. Documentos necessários</a></li>
-                <li><a href="#prazos" className="text-blue-600 hover:text-blue-800">5. Prazos e situações especiais</a></li>
-                <li><a href="#coimas" className="text-blue-600 hover:text-blue-800">6. Coimas por incumprimento</a></li>
-                <li><a href="#alteracoes" className="text-blue-600 hover:text-blue-800">7. Alterações e rescisões de contrato</a></li>
-                <li><a href="#faq" className="text-blue-600 hover:text-blue-800">8. Perguntas frequentes</a></li>
+                <li><a href="#obrigacao-legal" className="text-brand-600 hover:text-brand-800">1. Porquê é obrigatório registar?</a></li>
+                <li><a href="#o-que-registar" className="text-brand-600 hover:text-brand-800">2. O que tem de comunicar à AT</a></li>
+                <li><a href="#passo-a-passo" className="text-brand-600 hover:text-brand-800">3. Passo a passo no Portal das Finanças</a></li>
+                <li><a href="#documentos" className="text-brand-600 hover:text-brand-800">4. Documentos necessários</a></li>
+                <li><a href="#prazos" className="text-brand-600 hover:text-brand-800">5. Prazos e situações especiais</a></li>
+                <li><a href="#coimas" className="text-brand-600 hover:text-brand-800">6. Coimas por incumprimento</a></li>
+                <li><a href="#alteracoes" className="text-brand-600 hover:text-brand-800">7. Alterações e rescisões de contrato</a></li>
+                <li><a href="#faq" className="text-brand-600 hover:text-brand-800">8. Perguntas frequentes</a></li>
               </ol>
             </nav>
 
@@ -176,7 +176,7 @@ export default function RegistoContratoArrendamento2026Page() {
                 },
               ].map((s) => (
                 <div key={s.step} className="flex gap-4 bg-gray-50 rounded-xl p-5">
-                  <div className="w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-bold text-sm flex-shrink-0">
+                  <div className="w-8 h-8 bg-brand-600 text-white rounded-full flex items-center justify-center font-bold text-sm flex-shrink-0">
                     {s.step}
                   </div>
                   <div>
@@ -194,9 +194,9 @@ export default function RegistoContratoArrendamento2026Page() {
             </p>
 
             <div className="not-prose grid md:grid-cols-2 gap-4 mb-6">
-              <div className="bg-blue-50 rounded-xl p-5">
-                <h4 className="font-semibold text-blue-900 mb-3">Sobre o imóvel</h4>
-                <ul className="text-blue-800 space-y-1 text-sm">
+              <div className="bg-brand-50 rounded-xl p-5">
+                <h4 className="font-semibold text-brand-900 mb-3">Sobre o imóvel</h4>
+                <ul className="text-brand-800 space-y-1 text-sm">
                   <li>• Artigo matricial (caderneta predial)</li>
                   <li>• Fração (se for apartamento: fração A, B...)</li>
                   <li>• Morada completa com código postal</li>
@@ -309,9 +309,9 @@ export default function RegistoContratoArrendamento2026Page() {
               arrendamento naquele imóvel.
             </p>
 
-            <div className="not-prose bg-blue-50 border border-blue-200 rounded-xl p-5 my-6">
-              <h4 className="text-blue-900 font-semibold mb-2">Sobre os recibos eletrónicos</h4>
-              <p className="text-blue-800 text-sm">
+            <div className="not-prose bg-brand-50 border border-brand-200 rounded-xl p-5 my-6">
+              <h4 className="text-brand-900 font-semibold mb-2">Sobre os recibos eletrónicos</h4>
+              <p className="text-brand-800 text-sm">
                 Registar o contrato na AT é o passo inicial. Depois, cada mês, tem de emitir
                 recibos eletrónicos no Portal das Finanças para cada renda recebida.
                 Os dois processos estão relacionados mas são distintos.{" "}
@@ -353,24 +353,24 @@ export default function RegistoContratoArrendamento2026Page() {
               ))}
             </div>
 
-            <div className="not-prose mt-10 bg-gradient-to-r from-blue-600 to-indigo-600 rounded-xl p-8 text-white text-center">
+            <div className="not-prose mt-10 bg-gradient-to-r from-brand-600 to-brand-700 rounded-xl p-8 text-white text-center">
               <h3 className="text-xl font-bold mb-3">
                 Gerencie todos os seus arrendamentos num só lugar
               </h3>
-              <p className="text-blue-100 mb-6 text-sm max-w-lg mx-auto">
+              <p className="text-brand-100 mb-6 text-sm max-w-lg mx-auto">
                 O Senhorio ajuda-o a controlar prazos, rendas, recibos e obrigações fiscais —
                 tudo em português e desenhado para a realidade dos senhorios portugueses.
               </p>
               <div className="flex flex-col sm:flex-row gap-3 justify-center">
                 <Link
                   href="/#waitlist"
-                  className="px-6 py-3 bg-white text-blue-600 rounded-lg font-medium hover:bg-gray-100 transition text-sm"
+                  className="px-6 py-3 bg-white text-brand-600 rounded-lg font-medium hover:bg-gray-100 transition text-sm"
                 >
                   Entrar na Lista de Espera
                 </Link>
                 <Link
                   href="/blog/recibos-renda-eletronicos-guia-2026"
-                  className="px-6 py-3 border border-white text-white rounded-lg font-medium hover:bg-white hover:text-blue-600 transition text-sm"
+                  className="px-6 py-3 border border-white text-white rounded-lg font-medium hover:bg-white hover:text-brand-600 transition text-sm"
                 >
                   Ver Guia de Recibos
                 </Link>
@@ -388,21 +388,21 @@ export default function RegistoContratoArrendamento2026Page() {
                 Recibos de Renda Eletrónicos: Guia 2026
               </h3>
               <p className="text-gray-500 text-xs mb-3">Como emitir no Portal das Finanças.</p>
-              <span className="text-blue-600 text-xs font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-xs font-medium">Ler artigo →</span>
             </Link>
             <Link href="/blog/como-calcular-atualizacoes-renda-2026" className="border border-gray-200 rounded-xl p-5 hover:shadow-lg transition block">
               <h3 className="font-semibold text-gray-900 mb-2 text-sm">
                 Atualização de Rendas 2026
               </h3>
               <p className="text-gray-500 text-xs mb-3">Coeficiente INE 2,24% e regras NRAU.</p>
-              <span className="text-blue-600 text-xs font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-xs font-medium">Ler artigo →</span>
             </Link>
             <Link href="/blog/despesas-dedutiveis-arrendamento-2026" className="border border-gray-200 rounded-xl p-5 hover:shadow-lg transition block">
               <h3 className="font-semibold text-gray-900 mb-2 text-sm">
                 Despesas Dedutíveis no IRS 2026
               </h3>
               <p className="text-gray-500 text-xs mb-3">O que pode declarar para pagar menos.</p>
-              <span className="text-blue-600 text-xs font-medium">Ler artigo →</span>
+              <span className="text-brand-600 text-xs font-medium">Ler artigo →</span>
             </Link>
           </div>
         </section>

--- a/src/app/blog/simulador-fiscal-senhorios-2026/page.tsx
+++ b/src/app/blog/simulador-fiscal-senhorios-2026/page.tsx
@@ -43,7 +43,7 @@ export default function SimuladorFiscalSenhoriosPage() {
             <span>14 min leitura</span>
             <span>•</span>
             <div className="flex gap-2">
-              <span className="px-2 py-1 bg-blue-100 text-blue-600 text-xs rounded">Simulador Fiscal</span>
+              <span className="px-2 py-1 bg-brand-100 text-brand-600 text-xs rounded">Simulador Fiscal</span>
               <span className="px-2 py-1 bg-green-100 text-green-600 text-xs rounded">Calculadora Grátis</span>
               <span className="px-2 py-1 bg-purple-100 text-purple-600 text-xs rounded">Guia 2026</span>
             </div>
@@ -56,22 +56,22 @@ export default function SimuladorFiscalSenhoriosPage() {
         <div className="prose prose-gray max-w-none">
 
           {/* Introduction */}
-          <div className="bg-blue-50 border border-blue-200 rounded-xl p-6 mb-8">
-            <h2 className="text-lg font-semibold text-blue-900 mb-3">🎯 TL;DR - Simulador Fiscal Rápido</h2>
-            <p className="text-blue-800 mb-4">
+          <div className="bg-brand-50 border border-brand-200 rounded-xl p-6 mb-8">
+            <h2 className="text-lg font-semibold text-brand-900 mb-3">🎯 TL;DR - Simulador Fiscal Rápido</h2>
+            <p className="text-brand-800 mb-4">
               Precisa de calcular impostos sobre rendas rapidamente? Use o nosso <strong>simulador fiscal gratuito</strong>
               que compara automaticamente os 4 regimes fiscais portugueses e mostra qual é mais vantajoso para si.
             </p>
             <div className="flex flex-col sm:flex-row gap-3">
               <Link
                 href="/calculadora"
-                className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition text-center"
+                className="inline-block px-6 py-3 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 transition text-center"
               >
                 🧮 Abrir Simulador Fiscal
               </Link>
               <Link
                 href="/calculadora-rendas"
-                className="inline-block px-6 py-3 border border-blue-300 text-blue-700 rounded-lg font-medium hover:bg-blue-50 transition text-center"
+                className="inline-block px-6 py-3 border border-brand-300 text-brand-700 rounded-lg font-medium hover:bg-brand-50 transition text-center"
               >
                 📈 Calculadora de Rendas
               </Link>
@@ -132,14 +132,14 @@ export default function SimuladorFiscalSenhoriosPage() {
                   </div>
                 </div>
 
-                <div className="border border-blue-200 rounded-lg p-5 bg-blue-50">
-                  <h3 className="font-semibold text-blue-900 mb-3">2. Taxa Liberatória 28%</h3>
-                  <p className="text-blue-700 text-sm mb-3">
+                <div className="border border-brand-200 rounded-lg p-5 bg-brand-50">
+                  <h3 className="font-semibold text-brand-900 mb-3">2. Taxa Liberatória 28%</h3>
+                  <p className="text-brand-700 text-sm mb-3">
                     Taxa fixa de 28% sobre as rendas brutas, sem englobar com outros rendimentos.
                   </p>
                   <div className="text-sm">
                     <span className="font-medium text-green-600">Vantagens:</span>
-                    <ul className="text-blue-700 mt-1 space-y-1">
+                    <ul className="text-brand-700 mt-1 space-y-1">
                       <li>• Taxa fixa, fácil de calcular</li>
                       <li>• Não influencia escalões de IRS</li>
                       <li>• Boa para rendimentos médios/altos</li>
@@ -195,20 +195,20 @@ export default function SimuladorFiscalSenhoriosPage() {
 
               <div className="space-y-6">
                 <div className="flex items-start space-x-4">
-                  <div className="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-semibold">
+                  <div className="flex-shrink-0 w-8 h-8 bg-brand-600 text-white rounded-full flex items-center justify-center font-semibold">
                     1
                   </div>
                   <div>
                     <h3 className="font-semibold text-gray-900 mb-2">Aceda ao Simulador Fiscal</h3>
                     <p className="text-gray-700 mb-3">
-                      Visite o <Link href="/calculadora" className="text-blue-600 hover:underline">simulador fiscal Senhorio</Link>
+                      Visite o <Link href="/calculadora" className="text-brand-600 hover:underline">simulador fiscal Senhorio</Link>
                       - é gratuito e não requer registo.
                     </p>
                   </div>
                 </div>
 
                 <div className="flex items-start space-x-4">
-                  <div className="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-semibold">
+                  <div className="flex-shrink-0 w-8 h-8 bg-brand-600 text-white rounded-full flex items-center justify-center font-semibold">
                     2
                   </div>
                   <div>
@@ -216,14 +216,14 @@ export default function SimuladorFiscalSenhoriosPage() {
                     <p className="text-gray-700 mb-3">
                       Introduza o valor mensal das suas rendas. Se tem várias propriedades, some todos os valores.
                     </p>
-                    <div className="bg-blue-50 border border-blue-200 rounded p-3 text-sm">
+                    <div className="bg-brand-50 border border-brand-200 rounded p-3 text-sm">
                       <strong>Dica:</strong> Inclua rendas de garagens, lojas ou outros espaços arrendados.
                     </div>
                   </div>
                 </div>
 
                 <div className="flex items-start space-x-4">
-                  <div className="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-semibold">
+                  <div className="flex-shrink-0 w-8 h-8 bg-brand-600 text-white rounded-full flex items-center justify-center font-semibold">
                     3
                   </div>
                   <div>
@@ -236,7 +236,7 @@ export default function SimuladorFiscalSenhoriosPage() {
                 </div>
 
                 <div className="flex items-start space-x-4">
-                  <div className="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-semibold">
+                  <div className="flex-shrink-0 w-8 h-8 bg-brand-600 text-white rounded-full flex items-center justify-center font-semibold">
                     4
                   </div>
                   <div>
@@ -287,9 +287,9 @@ export default function SimuladorFiscalSenhoriosPage() {
                       <div className="font-medium text-red-800">IRS Geral</div>
                       <div className="text-red-600">€1.890/ano</div>
                     </div>
-                    <div className="bg-blue-50 p-3 rounded">
-                      <div className="font-medium text-blue-800">Taxa 28%</div>
-                      <div className="text-blue-600">€2.688/ano</div>
+                    <div className="bg-brand-50 p-3 rounded">
+                      <div className="font-medium text-brand-800">Taxa 28%</div>
+                      <div className="text-brand-600">€2.688/ano</div>
                     </div>
                     <div className="bg-green-50 p-3 rounded border border-green-300">
                       <div className="font-medium text-green-800">Taxa 10% ✅</div>
@@ -324,9 +324,9 @@ export default function SimuladorFiscalSenhoriosPage() {
                       <div className="font-medium text-green-800">IRS Geral ✅</div>
                       <div className="text-green-600">€1.620/ano</div>
                     </div>
-                    <div className="bg-blue-50 p-3 rounded">
-                      <div className="font-medium text-blue-800">Taxa 28%</div>
-                      <div className="text-blue-600">€4.704/ano</div>
+                    <div className="bg-brand-50 p-3 rounded">
+                      <div className="font-medium text-brand-800">Taxa 28%</div>
+                      <div className="text-brand-600">€4.704/ano</div>
                     </div>
                     <div className="bg-gray-50 p-3 rounded">
                       <div className="font-medium text-gray-600">Taxa 10%</div>
@@ -344,9 +344,9 @@ export default function SimuladorFiscalSenhoriosPage() {
                 </div>
               </div>
 
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-                <h3 className="font-semibold text-blue-900 mb-2">🎯 Conclusão dos Exemplos</h3>
-                <p className="text-blue-800 text-sm">
+              <div className="bg-brand-50 border border-brand-200 rounded-lg p-4">
+                <h3 className="font-semibold text-brand-900 mb-2">🎯 Conclusão dos Exemplos</h3>
+                <p className="text-brand-800 text-sm">
                   Como pode ver, o regime fiscal ótimo varia drasticamente consoante a situação.
                   O simulador elimina as dúvidas e garante que escolhe sempre a opção mais vantajosa.
                 </p>
@@ -456,7 +456,7 @@ export default function SimuladorFiscalSenhoriosPage() {
           </div>
 
           {/* Call to Action */}
-          <div className="mt-12 bg-gradient-to-r from-blue-50 to-green-50 border border-blue-200 rounded-xl p-8 text-center">
+          <div className="mt-12 bg-gradient-to-r from-brand-50 to-green-50 border border-brand-200 rounded-xl p-8 text-center">
             <h2 className="text-2xl font-bold text-gray-900 mb-4">
               Pronto para Otimizar os Seus Impostos?
             </h2>
@@ -467,13 +467,13 @@ export default function SimuladorFiscalSenhoriosPage() {
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link
                 href="/calculadora"
-                className="px-8 py-4 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition"
+                className="px-8 py-4 bg-brand-600 text-white rounded-lg font-semibold hover:bg-brand-700 transition"
               >
                 🧮 Simular Impostos Agora
               </Link>
               <Link
                 href="/#waitlist"
-                className="px-8 py-4 border border-blue-300 text-blue-700 rounded-lg font-semibold hover:bg-blue-50 transition"
+                className="px-8 py-4 border border-brand-300 text-brand-700 rounded-lg font-semibold hover:bg-brand-50 transition"
               >
                 📧 Receber Dicas Fiscais
               </Link>

--- a/src/app/calculadora-rendas/page.tsx
+++ b/src/app/calculadora-rendas/page.tsx
@@ -203,7 +203,7 @@ export default function RentIncreaseCalculatorPage() {
                   placeholder="800"
                   min="0"
                   step="10"
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -215,7 +215,7 @@ export default function RentIncreaseCalculatorPage() {
                   type="date"
                   value={contractDate}
                   onChange={(e) => setContractDate(e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -228,7 +228,7 @@ export default function RentIncreaseCalculatorPage() {
                     onClick={() => setPropertyType("residential")}
                     className={`px-4 py-3 border rounded-lg font-medium transition ${
                       propertyType === "residential"
-                        ? "border-blue-500 bg-blue-50 text-blue-700"
+                        ? "border-brand-500 bg-brand-50 text-brand-700"
                         : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
                     }`}
                   >
@@ -238,7 +238,7 @@ export default function RentIncreaseCalculatorPage() {
                     onClick={() => setPropertyType("commercial")}
                     className={`px-4 py-3 border rounded-lg font-medium transition ${
                       propertyType === "commercial"
-                        ? "border-blue-500 bg-blue-50 text-blue-700"
+                        ? "border-brand-500 bg-brand-50 text-brand-700"
                         : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
                     }`}
                   >
@@ -255,7 +255,7 @@ export default function RentIncreaseCalculatorPage() {
                   type="date"
                   value={lastIncreaseDate}
                   onChange={(e) => setLastIncreaseDate(e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
                 <p className="text-sm text-gray-500 mt-1">
                   Se nunca houve aumento, deixe em branco
@@ -300,14 +300,14 @@ export default function RentIncreaseCalculatorPage() {
                 </div>
               </div>
 
-              <div className="bg-blue-50 rounded-lg p-4 mt-4">
-                <p className="text-sm text-blue-700 font-medium mb-1">
+              <div className="bg-brand-50 rounded-lg p-4 mt-4">
+                <p className="text-sm text-brand-700 font-medium mb-1">
                   Regime Aplicável
                 </p>
-                <p className="text-blue-800 font-semibold">
+                <p className="text-brand-800 font-semibold">
                   {applicableRule.name}
                 </p>
-                <p className="text-sm text-blue-600">
+                <p className="text-sm text-brand-600">
                   {applicableRule.description}
                 </p>
               </div>
@@ -322,7 +322,7 @@ export default function RentIncreaseCalculatorPage() {
           </h2>
 
           <div className="grid md:grid-cols-1 gap-6">
-            <div className="bg-white rounded-xl shadow-sm p-6 border-2 border-blue-200">
+            <div className="bg-white rounded-xl shadow-sm p-6 border-2 border-brand-200">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">
                 {applicableRule.name}
               </h3>
@@ -337,7 +337,7 @@ export default function RentIncreaseCalculatorPage() {
                     <p className="text-sm font-medium text-gray-700 mb-2">
                       Coeficiente de Atualização:
                     </p>
-                    <p className="text-2xl font-bold text-blue-600">
+                    <p className="text-2xl font-bold text-brand-600">
                       {applicableRule.coefficient}%
                     </p>
                   </div>
@@ -388,11 +388,11 @@ export default function RentIncreaseCalculatorPage() {
             </ul>
           </div>
 
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-            <h3 className="font-semibold text-blue-800 mb-2">
+          <div className="bg-brand-50 border border-brand-200 rounded-lg p-4">
+            <h3 className="font-semibold text-brand-800 mb-2">
               Como Proceder
             </h3>
-            <ul className="text-sm text-blue-700 space-y-2">
+            <ul className="text-sm text-brand-700 space-y-2">
               <li>• Envie carta registada ao inquilino com 30 dias de antecedência</li>
               <li>• Indique claramente o valor do novo aumento</li>
               <li>• Mencione o coeficiente INE 2026 (2,24%) como fundamento</li>
@@ -466,17 +466,17 @@ export default function RentIncreaseCalculatorPage() {
         )}
 
         {/* CTA */}
-        <div className="mt-8 bg-blue-50 rounded-xl p-6 text-center">
-          <h3 className="text-lg font-semibold text-blue-900 mb-2">
+        <div className="mt-8 bg-brand-50 rounded-xl p-6 text-center">
+          <h3 className="text-lg font-semibold text-brand-900 mb-2">
             Precisa de gerir mais propriedades?
           </h3>
-          <p className="text-blue-700 mb-4">
+          <p className="text-brand-700 mb-4">
             A plataforma Senhorio vai ajudá-lo a gerir todas as suas propriedades,
             controlar aumentos de renda, e manter-se em conformidade com a lei portuguesa.
           </p>
           <Link
             href="/"
-            className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition"
+            className="inline-block px-6 py-3 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 transition"
           >
             Juntar à Lista de Espera
           </Link>

--- a/src/app/calculadora/page.tsx
+++ b/src/app/calculadora/page.tsx
@@ -174,16 +174,16 @@ export default function TaxCalculatorPage() {
 
       <div className="max-w-6xl mx-auto px-6 py-8">
         {/* 2026 Update Highlight */}
-        <div className="bg-blue-600 text-white rounded-xl p-6 mb-8">
+        <div className="bg-brand-600 text-white rounded-xl p-6 mb-8">
           <div className="flex items-start">
             <div className="text-3xl mr-4">🆕</div>
             <div>
               <h2 className="text-xl font-bold mb-2">Nova Lei IRS 2026: Taxa Especial 10%</h2>
-              <p className="text-blue-100 mb-3">
+              <p className="text-brand-100 mb-3">
                 A partir de 2026, rendas até €2.300/mês beneficiam de uma taxa reduzida de apenas 10%,
                 em vez dos habituais 25%.
               </p>
-              <div className="bg-blue-500/30 rounded-lg p-3">
+              <div className="bg-brand-500/30 rounded-lg p-3">
                 <p className="text-sm font-medium">
                   ⚠️ <strong>Atenção:</strong> Esta medida cria um incentivo perverso -
                   rendas de €2.300 podem gerar mais lucro líquido que rendas de €2.600!
@@ -212,7 +212,7 @@ export default function TaxCalculatorPage() {
                   placeholder="1000"
                   min="0"
                   step="50"
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -223,7 +223,7 @@ export default function TaxCalculatorPage() {
                 <select
                   value={municipality}
                   onChange={(e) => setMunicipality(e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 >
                   {MUNICIPALITIES.map((muni) => (
                     <option key={muni.code} value={muni.code}>
@@ -240,7 +240,7 @@ export default function TaxCalculatorPage() {
                 <select
                   value={propertyCount}
                   onChange={(e) => setPropertyCount(e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 >
                   {[1,2,3,4,5].map((num) => (
                     <option key={num} value={num}>
@@ -259,7 +259,7 @@ export default function TaxCalculatorPage() {
                     onClick={() => setResidency("resident")}
                     className={`px-4 py-3 border rounded-lg font-medium transition ${
                       residency === "resident"
-                        ? "border-blue-500 bg-blue-50 text-blue-700"
+                        ? "border-brand-500 bg-brand-50 text-brand-700"
                         : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
                     }`}
                   >
@@ -269,7 +269,7 @@ export default function TaxCalculatorPage() {
                     onClick={() => setResidency("non-resident")}
                     className={`px-4 py-3 border rounded-lg font-medium transition ${
                       residency === "non-resident"
-                        ? "border-blue-500 bg-blue-50 text-blue-700"
+                        ? "border-brand-500 bg-brand-50 text-brand-700"
                         : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
                     }`}
                   >
@@ -330,7 +330,7 @@ export default function TaxCalculatorPage() {
 
         {/* Email Capture for Tax Report */}
         {bestRegime && bestRegime.savings && bestRegime.savings > 0 && !emailSubmitted && (
-          <div className="mt-8 bg-gradient-to-r from-green-50 to-blue-50 rounded-xl border border-green-200 p-6">
+          <div className="mt-8 bg-gradient-to-r from-green-50 to-brand-50 rounded-xl border border-green-200 p-6">
             <div className="text-center">
               <div className="text-2xl mb-2">📧</div>
               <h3 className="text-lg font-semibold text-gray-900 mb-2">
@@ -349,12 +349,12 @@ export default function TaxCalculatorPage() {
                     onChange={(e) => setEmail(e.target.value)}
                     placeholder="o-seu-email@exemplo.com"
                     required
-                    className="flex-1 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="flex-1 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                   />
                   <button
                     type="submit"
                     disabled={emailLoading || !email}
-                    className="px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                    className="px-6 py-3 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition"
                   >
                     {emailLoading ? 'A enviar...' : 'Receber Relatório'}
                   </button>
@@ -396,7 +396,7 @@ export default function TaxCalculatorPage() {
                   regime === bestRegime && regime.eligible
                     ? "border-green-400 bg-green-50"
                     : regime.eligible
-                    ? "border-gray-200 hover:border-blue-300"
+                    ? "border-gray-200 hover:border-brand-300"
                     : "border-gray-200 bg-gray-50 opacity-75"
                 }`}
               >
@@ -572,16 +572,16 @@ export default function TaxCalculatorPage() {
         </div>
 
         {/* CTA to waitlist */}
-        <div className="mt-8 bg-blue-50 rounded-xl p-6 text-center">
-          <h3 className="text-lg font-semibold text-blue-900 mb-2">
+        <div className="mt-8 bg-brand-50 rounded-xl p-6 text-center">
+          <h3 className="text-lg font-semibold text-brand-900 mb-2">
             Quer gerir as suas propriedades de forma mais eficiente?
           </h3>
-          <p className="text-blue-700 mb-4">
+          <p className="text-brand-700 mb-4">
             Junte-se à nossa lista de espera para ter acesso antecipado à plataforma completa Senhorio.
           </p>
           <Link
             href="/"
-            className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition"
+            className="inline-block px-6 py-3 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 transition"
           >
             Juntar à Lista de Espera
           </Link>

--- a/src/app/cookies/page.tsx
+++ b/src/app/cookies/page.tsx
@@ -20,7 +20,7 @@ export default function CookiesPage() {
       {/* Header */}
       <header className="border-b border-gray-200">
         <div className="max-w-4xl mx-auto px-6 py-6">
-          <Link href="/" className="text-sm text-blue-600 hover:text-blue-700 transition">
+          <Link href="/" className="text-sm text-brand-600 hover:text-brand-700 transition">
             ← Voltar ao Senhorio
           </Link>
           <h1 className="text-3xl font-bold text-gray-900 mt-4">
@@ -80,19 +80,19 @@ export default function CookiesPage() {
           <p className="text-gray-600 mb-4">
             Utilizamos o Vercel Analytics para compreender como o site é usado:
           </p>
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
+          <div className="bg-brand-50 border border-brand-200 rounded-lg p-4 mb-6">
             <div className="space-y-3">
               <div>
-                <strong className="text-blue-900">Vercel Analytics</strong>
-                <p className="text-sm text-blue-800">Recolhe dados anónimos sobre visualizações de páginas e comportamento</p>
-                <p className="text-xs text-blue-600">Duração: 26 meses</p>
-                <p className="text-xs text-blue-600">Finalidade: Melhorar a performance e experiência do utilizador</p>
+                <strong className="text-brand-900">Vercel Analytics</strong>
+                <p className="text-sm text-brand-800">Recolhe dados anónimos sobre visualizações de páginas e comportamento</p>
+                <p className="text-xs text-brand-600">Duração: 26 meses</p>
+                <p className="text-xs text-brand-600">Finalidade: Melhorar a performance e experiência do utilizador</p>
               </div>
               <div>
-                <strong className="text-blue-900">Vercel Speed Insights</strong>
-                <p className="text-sm text-blue-800">Monitoriza a velocidade de carregamento do site</p>
-                <p className="text-xs text-blue-600">Duração: 26 meses</p>
-                <p className="text-xs text-blue-600">Finalidade: Otimizar performance técnica</p>
+                <strong className="text-brand-900">Vercel Speed Insights</strong>
+                <p className="text-sm text-brand-800">Monitoriza a velocidade de carregamento do site</p>
+                <p className="text-xs text-brand-600">Duração: 26 meses</p>
+                <p className="text-xs text-brand-600">Finalidade: Otimizar performance técnica</p>
               </div>
             </div>
           </div>
@@ -136,8 +136,8 @@ export default function CookiesPage() {
                 <tr>
                   <td className="px-4 py-3 text-sm text-gray-900">Vercel Analytics</td>
                   <td className="px-4 py-3 text-sm text-gray-600">Analytics anónimos do website</td>
-                  <td className="px-4 py-3 text-sm text-blue-600">
-                    <a href="https://vercel.com/docs/analytics/privacy-policy" target="_blank" rel="noopener" className="hover:text-blue-700">
+                  <td className="px-4 py-3 text-sm text-brand-600">
+                    <a href="https://vercel.com/docs/analytics/privacy-policy" target="_blank" rel="noopener" className="hover:text-brand-700">
                       Ver política →
                     </a>
                   </td>
@@ -145,8 +145,8 @@ export default function CookiesPage() {
                 <tr>
                   <td className="px-4 py-3 text-sm text-gray-900">Vercel Speed Insights</td>
                   <td className="px-4 py-3 text-sm text-gray-600">Monitorização de performance</td>
-                  <td className="px-4 py-3 text-sm text-blue-600">
-                    <a href="https://vercel.com/docs/speed-insights/privacy-policy" target="_blank" rel="noopener" className="hover:text-blue-700">
+                  <td className="px-4 py-3 text-sm text-brand-600">
+                    <a href="https://vercel.com/docs/speed-insights/privacy-policy" target="_blank" rel="noopener" className="hover:text-brand-700">
                       Ver política →
                     </a>
                   </td>
@@ -233,9 +233,9 @@ export default function CookiesPage() {
           </div>
         </section>
 
-        <section className="bg-blue-50 border border-blue-200 rounded-lg p-6 mt-12">
-          <h3 className="text-lg font-semibold text-blue-900 mb-2">Compromisso com a Privacidade</h3>
-          <p className="text-blue-800 text-sm">
+        <section className="bg-brand-50 border border-brand-200 rounded-lg p-6 mt-12">
+          <h3 className="text-lg font-semibold text-brand-900 mb-2">Compromisso com a Privacidade</h3>
+          <p className="text-brand-800 text-sm">
             O Senhorio utiliza cookies de forma responsável e transparente. Não utilizamos cookies
             para rastreamento invasivo ou partilha de dados com terceiros para fins publicitários.
             O nosso foco é melhorar a sua experiência e fornecer as melhores ferramentas para

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -56,7 +56,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="w-8 h-8 bg-blue-600 rounded-lg mx-auto mb-4"></div>
+          <div className="w-8 h-8 bg-brand-600 rounded-lg mx-auto mb-4"></div>
           <div className="text-lg font-semibold text-gray-900 mb-2">Senhorio</div>
           <div className="text-sm text-gray-500">A carregar...</div>
         </div>
@@ -69,7 +69,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       {/* Mobile header */}
       <div className="lg:hidden bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
         <div className="flex items-center space-x-2">
-          <div className="w-8 h-8 bg-blue-600 rounded-lg"></div>
+          <div className="w-8 h-8 bg-brand-600 rounded-lg"></div>
           <span className="text-lg font-bold text-gray-900">Senhorio</span>
         </div>
         <button
@@ -91,7 +91,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           <div className="h-full flex flex-col">
             {/* Logo */}
             <div className="hidden lg:flex items-center space-x-2 px-6 py-5 border-b border-gray-200">
-              <div className="w-8 h-8 bg-blue-600 rounded-lg"></div>
+              <div className="w-8 h-8 bg-brand-600 rounded-lg"></div>
               <span className="text-lg font-bold text-gray-900">Senhorio</span>
             </div>
 
@@ -106,7 +106,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                     onClick={() => setSidebarOpen(false)}
                     className={`flex items-center space-x-3 px-3 py-2.5 rounded-lg text-sm font-medium transition ${
                       isActive
-                        ? "bg-blue-50 text-blue-700"
+                        ? "bg-brand-50 text-brand-700"
                         : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
                     }`}
                   >

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -108,7 +108,7 @@ export default function DashboardPage() {
   ];
 
   const colorMap: Record<string, string> = {
-    blue: "bg-blue-50 text-blue-600",
+    blue: "bg-brand-50 text-brand-600",
     green: "bg-green-50 text-green-600",
     yellow: "bg-yellow-50 text-yellow-600",
     red: "bg-red-50 text-red-600",
@@ -140,7 +140,7 @@ export default function DashboardPage() {
         <h1 className="text-2xl font-bold text-gray-900">Painel de Gestão</h1>
         <Link
           href="/dashboard/properties"
-          className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition"
+          className="px-4 py-2 bg-brand-600 text-white text-sm font-medium rounded-lg hover:bg-brand-700 transition"
         >
           + Adicionar Imóvel
         </Link>
@@ -171,7 +171,7 @@ export default function DashboardPage() {
       <div className="bg-white rounded-xl shadow-sm border border-gray-100">
         <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
           <h2 className="text-lg font-semibold text-gray-900">Pagamentos Recentes</h2>
-          <Link href="/dashboard/payments" className="text-sm text-blue-600 font-medium hover:text-blue-700">
+          <Link href="/dashboard/payments" className="text-sm text-brand-600 font-medium hover:text-brand-700">
             Ver todos
           </Link>
         </div>
@@ -210,11 +210,11 @@ export default function DashboardPage() {
 
       {/* Quick start guide for empty state */}
       {stats.totalProperties === 0 && (
-        <div className="mt-8 bg-blue-50 border border-blue-200 rounded-xl p-8">
+        <div className="mt-8 bg-brand-50 border border-brand-200 rounded-xl p-8">
           <h3 className="text-lg font-bold text-gray-900 mb-4">Como começar</h3>
           <div className="grid md:grid-cols-3 gap-6">
             <div className="flex items-start space-x-3">
-              <div className="w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0">
+              <div className="w-8 h-8 bg-brand-600 text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0">
                 1
               </div>
               <div>
@@ -223,7 +223,7 @@ export default function DashboardPage() {
               </div>
             </div>
             <div className="flex items-start space-x-3">
-              <div className="w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0">
+              <div className="w-8 h-8 bg-brand-600 text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0">
                 2
               </div>
               <div>
@@ -232,7 +232,7 @@ export default function DashboardPage() {
               </div>
             </div>
             <div className="flex items-start space-x-3">
-              <div className="w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0">
+              <div className="w-8 h-8 bg-brand-600 text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0">
                 3
               </div>
               <div>

--- a/src/app/dashboard/properties/[id]/page.tsx
+++ b/src/app/dashboard/properties/[id]/page.tsx
@@ -291,7 +291,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
               resetForm();
               setShowForm(!showForm);
             }}
-            className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition"
+            className="px-4 py-2 bg-brand-600 text-white text-sm font-medium rounded-lg hover:bg-brand-700 transition"
           >
             {showForm ? "Cancelar" : "+ Adicionar Inquilino"}
           </button>
@@ -316,7 +316,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
                   value={form.name}
                   onChange={(e) => setForm({ ...form, name: e.target.value })}
                   placeholder="Nome completo do inquilino"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -329,7 +329,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
                   value={form.email}
                   onChange={(e) => setForm({ ...form, email: e.target.value })}
                   placeholder="email@exemplo.com"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -342,7 +342,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
                   value={form.phone}
                   onChange={(e) => setForm({ ...form, phone: e.target.value })}
                   placeholder="912 345 678"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -355,7 +355,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
                   value={form.nif}
                   onChange={(e) => setForm({ ...form, nif: e.target.value })}
                   placeholder="123456789"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -368,7 +368,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
                   required
                   value={form.contract_start}
                   onChange={(e) => setForm({ ...form, contract_start: e.target.value })}
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -380,7 +380,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
                   type="date"
                   value={form.contract_end}
                   onChange={(e) => setForm({ ...form, contract_end: e.target.value })}
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -391,7 +391,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
                 <select
                   value={form.contract_type}
                   onChange={(e) => setForm({ ...form, contract_type: e.target.value })}
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 >
                   <option value="residential">Habitação</option>
                   <option value="commercial">Comercial</option>
@@ -411,7 +411,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
                   value={form.rent_amount}
                   onChange={(e) => setForm({ ...form, rent_amount: e.target.value })}
                   placeholder="750.00"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -422,7 +422,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
                 <select
                   value={form.payment_day}
                   onChange={(e) => setForm({ ...form, payment_day: e.target.value })}
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 >
                   {Array.from({ length: 31 }, (_, i) => i + 1).map((day) => (
                     <option key={day} value={day}>Dia {day}</option>
@@ -440,7 +440,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
                   value={form.deposit_amount}
                   onChange={(e) => setForm({ ...form, deposit_amount: e.target.value })}
                   placeholder="750.00"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -451,7 +451,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
                 <select
                   value={form.status}
                   onChange={(e) => setForm({ ...form, status: e.target.value })}
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 >
                   <option value="active">Ativo</option>
                   <option value="inactive">Inativo</option>
@@ -477,7 +477,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
               <button
                 type="submit"
                 disabled={saving}
-                className="px-6 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition disabled:opacity-50"
+                className="px-6 py-2 bg-brand-600 text-white text-sm font-medium rounded-lg hover:bg-brand-700 transition disabled:opacity-50"
               >
                 {saving
                   ? (editingTenant ? "A atualizar..." : "A guardar...")
@@ -499,7 +499,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
           <p className="text-gray-500 mb-6">Adicione o primeiro inquilino deste imóvel.</p>
           <button
             onClick={() => setShowForm(true)}
-            className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition"
+            className="px-6 py-3 bg-brand-600 text-white font-medium rounded-lg hover:bg-brand-700 transition"
           >
             + Adicionar Primeiro Inquilino
           </button>
@@ -552,7 +552,7 @@ export default function PropertyTenantsPage({ params }: { params: Promise<{ id: 
                     <div className="flex flex-col space-y-2">
                       <button
                         onClick={() => startEdit(tenant)}
-                        className="p-2 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition"
+                        className="p-2 text-gray-600 hover:text-brand-600 hover:bg-brand-50 rounded-lg transition"
                         title="Editar inquilino"
                       >
                         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/app/dashboard/properties/page.tsx
+++ b/src/app/dashboard/properties/page.tsx
@@ -201,7 +201,7 @@ export default function PropertiesPage() {
             resetForm();
             setShowForm(!showForm);
           }}
-          className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition"
+          className="px-4 py-2 bg-brand-600 text-white text-sm font-medium rounded-lg hover:bg-brand-700 transition"
         >
           {showForm ? "Cancelar" : "+ Adicionar Imóvel"}
         </button>
@@ -225,7 +225,7 @@ export default function PropertiesPage() {
                   value={form.address}
                   onChange={(e) => setForm({ ...form, address: e.target.value })}
                   placeholder="Rua, número, andar"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -238,7 +238,7 @@ export default function PropertiesPage() {
                   value={form.city}
                   onChange={(e) => setForm({ ...form, city: e.target.value })}
                   placeholder="Ex: Lisboa"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -251,7 +251,7 @@ export default function PropertiesPage() {
                   value={form.municipality}
                   onChange={(e) => setForm({ ...form, municipality: e.target.value })}
                   placeholder="Ex: Lisboa"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -262,7 +262,7 @@ export default function PropertiesPage() {
                 <select
                   value={form.property_type}
                   onChange={(e) => setForm({ ...form, property_type: e.target.value })}
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 >
                   <option value="apartment">Apartamento</option>
                   <option value="house">Moradia</option>
@@ -278,7 +278,7 @@ export default function PropertiesPage() {
                 <select
                   value={form.typology}
                   onChange={(e) => setForm({ ...form, typology: e.target.value })}
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 >
                   <option value="">Selecionar</option>
                   <option value="T0">T0</option>
@@ -299,7 +299,7 @@ export default function PropertiesPage() {
                   value={form.area_m2}
                   onChange={(e) => setForm({ ...form, area_m2: e.target.value })}
                   placeholder="Ex: 85"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -312,7 +312,7 @@ export default function PropertiesPage() {
                   value={form.year_built}
                   onChange={(e) => setForm({ ...form, year_built: e.target.value })}
                   placeholder="Ex: 2005"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -325,7 +325,7 @@ export default function PropertiesPage() {
                   value={form.license_number}
                   onChange={(e) => setForm({ ...form, license_number: e.target.value })}
                   placeholder="Número da licença"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -339,7 +339,7 @@ export default function PropertiesPage() {
                   value={form.fiscal_value}
                   onChange={(e) => setForm({ ...form, fiscal_value: e.target.value })}
                   placeholder="Ex: 120000"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -350,7 +350,7 @@ export default function PropertiesPage() {
                 <select
                   value={form.status}
                   onChange={(e) => setForm({ ...form, status: e.target.value })}
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 >
                   <option value="active">Ativo</option>
                   <option value="inactive">Inativo</option>
@@ -376,7 +376,7 @@ export default function PropertiesPage() {
               <button
                 type="submit"
                 disabled={saving}
-                className="px-6 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition disabled:opacity-50"
+                className="px-6 py-2 bg-brand-600 text-white text-sm font-medium rounded-lg hover:bg-brand-700 transition disabled:opacity-50"
               >
                 {saving
                   ? (editingProperty ? "A atualizar..." : "A guardar...")
@@ -398,7 +398,7 @@ export default function PropertiesPage() {
           <p className="text-gray-500 mb-6">Adicione o seu primeiro imóvel para começar a gerir o arrendamento.</p>
           <button
             onClick={() => setShowForm(true)}
-            className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition"
+            className="px-6 py-3 bg-brand-600 text-white font-medium rounded-lg hover:bg-brand-700 transition"
           >
             + Adicionar Primeiro Imóvel
           </button>
@@ -451,7 +451,7 @@ export default function PropertiesPage() {
                       </a>
                       <button
                         onClick={() => startEdit(property)}
-                        className="p-2 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition"
+                        className="p-2 text-gray-600 hover:text-brand-600 hover:bg-brand-50 rounded-lg transition"
                         title="Editar imóvel"
                       >
                         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/app/dashboard/receipts/[id]/page.tsx
+++ b/src/app/dashboard/receipts/[id]/page.tsx
@@ -91,7 +91,7 @@ export default function ReceiptViewPage({ params }: { params: Promise<{ id: stri
         <p className="text-gray-600 mb-6">{error || "O recibo que procura não existe ou foi removido."}</p>
         <button
           onClick={() => router.push("/dashboard/receipts")}
-          className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition"
+          className="px-6 py-3 bg-brand-600 text-white font-medium rounded-lg hover:bg-brand-700 transition"
         >
           Voltar aos Recibos
         </button>
@@ -115,7 +115,7 @@ export default function ReceiptViewPage({ params }: { params: Promise<{ id: stri
           </button>
           <button
             onClick={printReceipt}
-            className="bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition flex items-center"
+            className="bg-brand-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-brand-700 transition flex items-center"
           >
             <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V9a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />

--- a/src/app/dashboard/receipts/page.tsx
+++ b/src/app/dashboard/receipts/page.tsx
@@ -191,7 +191,7 @@ export default function ReceiptsPage() {
             resetForm();
             setShowForm(!showForm);
           }}
-          className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition"
+          className="px-4 py-2 bg-brand-600 text-white text-sm font-medium rounded-lg hover:bg-brand-700 transition"
           disabled={tenants.length === 0}
         >
           {showForm ? "Cancelar" : "+ Gerar Recibo"}
@@ -212,7 +212,7 @@ export default function ReceiptsPage() {
                   required
                   value={form.tenant_id}
                   onChange={(e) => setForm({ ...form, tenant_id: e.target.value })}
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 >
                   <option value="">Selecionar inquilino</option>
                   {tenants.map((tenant) => (
@@ -234,7 +234,7 @@ export default function ReceiptsPage() {
                   value={form.amount}
                   onChange={(e) => setForm({ ...form, amount: e.target.value })}
                   placeholder="Valor da renda"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -245,7 +245,7 @@ export default function ReceiptsPage() {
                 <select
                   value={form.period_month}
                   onChange={(e) => setForm({ ...form, period_month: parseInt(e.target.value) })}
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 >
                   {monthNames.map((month, index) => (
                     <option key={index + 1} value={index + 1}>{month}</option>
@@ -264,7 +264,7 @@ export default function ReceiptsPage() {
                   max="2030"
                   value={form.period_year}
                   onChange={(e) => setForm({ ...form, period_year: parseInt(e.target.value) })}
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -277,7 +277,7 @@ export default function ReceiptsPage() {
                   required
                   value={form.issue_date}
                   onChange={(e) => setForm({ ...form, issue_date: e.target.value })}
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -290,13 +290,13 @@ export default function ReceiptsPage() {
                   value={form.receipt_number}
                   onChange={(e) => setForm({ ...form, receipt_number: e.target.value })}
                   placeholder="Gerado automaticamente se vazio"
-                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
             </div>
 
             {selectedTenant && (
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+              <div className="bg-brand-50 border border-brand-200 rounded-lg p-4">
                 <h4 className="font-medium text-gray-900 mb-2">Detalhes do Inquilino</h4>
                 <div className="text-sm text-gray-600 space-y-1">
                   <p><strong>Nome:</strong> {selectedTenant.name}</p>
@@ -325,7 +325,7 @@ export default function ReceiptsPage() {
               <button
                 type="submit"
                 disabled={generating}
-                className="px-6 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition disabled:opacity-50"
+                className="px-6 py-2 bg-brand-600 text-white text-sm font-medium rounded-lg hover:bg-brand-700 transition disabled:opacity-50"
               >
                 {generating ? "A gerar..." : "Gerar Recibo"}
               </button>
@@ -344,7 +344,7 @@ export default function ReceiptsPage() {
           <p className="text-gray-500 mb-6">Para gerar recibos, primeiro precisa de adicionar inquilinos aos seus imóveis.</p>
           <Link
             href="/dashboard/properties"
-            className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition"
+            className="px-6 py-3 bg-brand-600 text-white font-medium rounded-lg hover:bg-brand-700 transition"
           >
             Gerir Imóveis
           </Link>
@@ -388,7 +388,7 @@ export default function ReceiptsPage() {
                     <Link
                       href={`/dashboard/receipts/${receipt.id}`}
                       target="_blank"
-                      className="p-2 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition"
+                      className="p-2 text-gray-600 hover:text-brand-600 hover:bg-brand-50 rounded-lg transition"
                       title="Ver recibo"
                     >
                       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/app/dashboard/tax-reports/page.tsx
+++ b/src/app/dashboard/tax-reports/page.tsx
@@ -143,7 +143,7 @@ export default function TaxReportsPage() {
           <select
             value={selectedYear}
             onChange={(e) => setSelectedYear(parseInt(e.target.value))}
-            className="px-4 py-2 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="px-4 py-2 border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-600"
           >
             {availableYears.map(year => (
               <option key={year} value={year}>{year}</option>
@@ -185,7 +185,7 @@ export default function TaxReportsPage() {
             </div>
             <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
               <h3 className="text-sm font-medium text-gray-500 mb-2">Rendimento Líquido</h3>
-              <p className="text-3xl font-bold text-blue-600">€{report.summary.total_net_income.toFixed(2)}</p>
+              <p className="text-3xl font-bold text-brand-600">€{report.summary.total_net_income.toFixed(2)}</p>
             </div>
           </div>
 
@@ -201,7 +201,7 @@ export default function TaxReportsPage() {
               <button
                 onClick={() => exportReport('csv')}
                 disabled={exporting}
-                className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition disabled:opacity-50 flex items-center"
+                className="px-6 py-3 bg-brand-600 text-white font-medium rounded-lg hover:bg-brand-700 transition disabled:opacity-50 flex items-center"
               >
                 <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -306,9 +306,9 @@ export default function TaxReportsPage() {
           </div>
 
           {/* Help Section */}
-          <div className="bg-blue-50 border border-blue-200 rounded-xl p-6">
-            <h3 className="text-lg font-semibold text-blue-900 mb-3">Como usar no Portal das Finanças</h3>
-            <div className="space-y-2 text-sm text-blue-800">
+          <div className="bg-brand-50 border border-brand-200 rounded-xl p-6">
+            <h3 className="text-lg font-semibold text-brand-900 mb-3">Como usar no Portal das Finanças</h3>
+            <div className="space-y-2 text-sm text-brand-800">
               <p>1. <strong>Faça download do ficheiro CSV</strong> clicando em "Exportar CSV"</p>
               <p>2. <strong>Aceda ao Portal das Finanças</strong> e navegue para a secção de IRS</p>
               <p>3. <strong>Use os dados do resumo</strong> para preencher os valores de rendas prediais</p>
@@ -327,7 +327,7 @@ export default function TaxReportsPage() {
           <p className="text-gray-500 mb-6">Não foi encontrada atividade fiscal para {selectedYear}.</p>
           <Link
             href="/dashboard/properties"
-            className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition"
+            className="px-6 py-3 bg-brand-600 text-white font-medium rounded-lg hover:bg-brand-700 transition"
           >
             Adicionar Imóveis
           </Link>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -49,11 +49,11 @@ function LoginForm() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50 flex items-center justify-center px-4">
+    <div className="min-h-screen bg-gradient-to-br from-brand-50 via-white to-brand-50 flex items-center justify-center px-4">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
           <Link href="/" className="inline-flex items-center space-x-2 mb-6">
-            <div className="w-10 h-10 bg-blue-600 rounded-lg"></div>
+            <div className="w-10 h-10 bg-brand-600 rounded-lg"></div>
             <span className="text-2xl font-bold text-gray-900">Senhorio</span>
           </Link>
           <h1 className="text-3xl font-bold text-gray-900">Iniciar Sessão</h1>
@@ -73,7 +73,7 @@ function LoginForm() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="o-seu@email.com"
-                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent transition"
               />
             </div>
 
@@ -88,7 +88,7 @@ function LoginForm() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 placeholder="A sua password"
-                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent transition"
               />
             </div>
 
@@ -101,7 +101,7 @@ function LoginForm() {
             <button
               type="submit"
               disabled={loading}
-              className="w-full px-6 py-3 bg-blue-600 text-white rounded-xl font-semibold hover:bg-blue-700 transition disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full px-6 py-3 bg-brand-600 text-white rounded-xl font-semibold hover:bg-brand-700 transition disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {loading ? "A entrar..." : "Entrar"}
             </button>
@@ -110,7 +110,7 @@ function LoginForm() {
           <div className="mt-6 text-center">
             <p className="text-gray-600 text-sm">
               Ainda não tem conta?{" "}
-              <Link href="/register" className="text-blue-600 font-medium hover:text-blue-700">
+              <Link href="/register" className="text-brand-600 font-medium hover:text-brand-700">
                 Criar conta
               </Link>
             </p>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -20,7 +20,7 @@ export default function PrivacyPage() {
       {/* Header */}
       <header className="border-b border-gray-200">
         <div className="max-w-4xl mx-auto px-6 py-6">
-          <Link href="/" className="text-sm text-blue-600 hover:text-blue-700 transition">
+          <Link href="/" className="text-sm text-brand-600 hover:text-brand-700 transition">
             ← Voltar ao Senhorio
           </Link>
           <h1 className="text-3xl font-bold text-gray-900 mt-4">
@@ -108,7 +108,7 @@ export default function PrivacyPage() {
             <li>• <strong>Limitação:</strong> Restringir como processamos os seus dados</li>
           </ul>
           <p className="text-gray-600 mt-4">
-            Para exercer qualquer destes direitos, contacte-nos em: <a href="mailto:privacy@senhorio.pt" className="text-blue-600 hover:text-blue-700">privacy@senhorio.pt</a>
+            Para exercer qualquer destes direitos, contacte-nos em: <a href="mailto:privacy@senhorio.pt" className="text-brand-600 hover:text-brand-700">privacy@senhorio.pt</a>
           </p>
         </section>
 
@@ -154,9 +154,9 @@ export default function PrivacyPage() {
           </div>
         </section>
 
-        <section className="bg-blue-50 border border-blue-200 rounded-lg p-6 mt-12">
-          <h3 className="text-lg font-semibold text-blue-900 mb-2">Sobre o Senhorio</h3>
-          <p className="text-blue-800 text-sm">
+        <section className="bg-brand-50 border border-brand-200 rounded-lg p-6 mt-12">
+          <h3 className="text-lg font-semibold text-brand-900 mb-2">Sobre o Senhorio</h3>
+          <p className="text-brand-800 text-sm">
             O Senhorio é uma plataforma de gestão de arrendamento desenvolvida especificamente para
             senhorios portugueses. Estamos comprometidos com a transparência e proteção da sua privacidade
             enquanto lhe fornecemos as ferramentas necessárias para gerir os seus imóveis em conformidade

--- a/src/app/recibos/page.tsx
+++ b/src/app/recibos/page.tsx
@@ -502,7 +502,7 @@ export default function ReceiptGeneratorPage() {
               <div className="mb-6 print:mb-4">
                 <button
                   onClick={printReceipt}
-                  className="bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition-colors print:hidden"
+                  className="bg-brand-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-brand-700 transition-colors print:hidden"
                 >
                   Imprimir / Guardar PDF
                 </button>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -52,11 +52,11 @@ export default function RegisterPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50 flex items-center justify-center px-4">
+    <div className="min-h-screen bg-gradient-to-br from-brand-50 via-white to-brand-50 flex items-center justify-center px-4">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
           <Link href="/" className="inline-flex items-center space-x-2 mb-6">
-            <div className="w-10 h-10 bg-blue-600 rounded-lg"></div>
+            <div className="w-10 h-10 bg-brand-600 rounded-lg"></div>
             <span className="text-2xl font-bold text-gray-900">Senhorio</span>
           </Link>
           <h1 className="text-3xl font-bold text-gray-900">Criar Conta</h1>
@@ -75,7 +75,7 @@ export default function RegisterPage() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="O seu nome (opcional)"
-                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent transition"
               />
             </div>
 
@@ -90,7 +90,7 @@ export default function RegisterPage() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="o-seu@email.com"
-                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent transition"
               />
             </div>
 
@@ -105,7 +105,7 @@ export default function RegisterPage() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 placeholder="Mínimo 6 caracteres"
-                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent transition"
               />
             </div>
 
@@ -120,7 +120,7 @@ export default function RegisterPage() {
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 placeholder="Repita a password"
-                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent transition"
               />
             </div>
 
@@ -133,7 +133,7 @@ export default function RegisterPage() {
             <button
               type="submit"
               disabled={loading}
-              className="w-full px-6 py-3 bg-blue-600 text-white rounded-xl font-semibold hover:bg-blue-700 transition disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full px-6 py-3 bg-brand-600 text-white rounded-xl font-semibold hover:bg-brand-700 transition disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {loading ? "A criar conta..." : "Criar Conta"}
             </button>
@@ -142,7 +142,7 @@ export default function RegisterPage() {
           <div className="mt-6 text-center">
             <p className="text-gray-600 text-sm">
               Já tem conta?{" "}
-              <Link href="/login" className="text-blue-600 font-medium hover:text-blue-700">
+              <Link href="/login" className="text-brand-600 font-medium hover:text-brand-700">
                 Iniciar sessão
               </Link>
             </p>

--- a/src/app/simulador-irs/page.tsx
+++ b/src/app/simulador-irs/page.tsx
@@ -145,7 +145,7 @@ export default function SimuladorIRSPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-green-50">
+    <div className="min-h-screen bg-gradient-to-br from-brand-50 via-white to-green-50">
       {/* Header with 2026 highlight */}
       <header className="bg-white border-b border-gray-200 shadow-sm">
         <div className="max-w-6xl mx-auto px-6 py-6">
@@ -174,7 +174,7 @@ export default function SimuladorIRSPage() {
 
       <div className="max-w-6xl mx-auto px-6 py-8">
         {/* Key benefits banner */}
-        <div className="bg-gradient-to-r from-green-600 to-blue-600 text-white rounded-xl p-6 mb-8">
+        <div className="bg-gradient-to-r from-brand-600 to-brand-700 text-white rounded-xl p-6 mb-8">
           <div className="grid md:grid-cols-3 gap-4 text-center">
             <div>
               <div className="text-2xl font-bold">10%</div>
@@ -210,7 +210,7 @@ export default function SimuladorIRSPage() {
                   placeholder="1200"
                   min="0"
                   step="50"
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-lg"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent text-lg"
                 />
                 <p className="text-sm text-gray-500 mt-1">
                   {parseFloat(monthlyRent) <= 2300 ?
@@ -228,7 +228,7 @@ export default function SimuladorIRSPage() {
                     onClick={() => setResidency("resident")}
                     className={`px-4 py-3 border rounded-lg font-medium transition ${
                       residency === "resident"
-                        ? "border-blue-500 bg-blue-50 text-blue-700"
+                        ? "border-brand-500 bg-brand-50 text-brand-700"
                         : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
                     }`}
                   >
@@ -238,7 +238,7 @@ export default function SimuladorIRSPage() {
                     onClick={() => setResidency("non-resident")}
                     className={`px-4 py-3 border rounded-lg font-medium transition ${
                       residency === "non-resident"
-                        ? "border-blue-500 bg-blue-50 text-blue-700"
+                        ? "border-brand-500 bg-brand-50 text-brand-700"
                         : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
                     }`}
                   >
@@ -256,7 +256,7 @@ export default function SimuladorIRSPage() {
                     onClick={() => setPropertyType("single")}
                     className={`px-4 py-3 border rounded-lg font-medium transition ${
                       propertyType === "single"
-                        ? "border-blue-500 bg-blue-50 text-blue-700"
+                        ? "border-brand-500 bg-brand-50 text-brand-700"
                         : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
                     }`}
                   >
@@ -266,7 +266,7 @@ export default function SimuladorIRSPage() {
                     onClick={() => setPropertyType("multiple")}
                     className={`px-4 py-3 border rounded-lg font-medium transition ${
                       propertyType === "multiple"
-                        ? "border-blue-500 bg-blue-50 text-blue-700"
+                        ? "border-brand-500 bg-brand-50 text-brand-700"
                         : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
                     }`}
                   >
@@ -334,7 +334,7 @@ export default function SimuladorIRSPage() {
 
         {/* Email Capture */}
         {bestScenario && bestScenario.savings && bestScenario.savings > 0 && !emailSubmitted && (
-          <div className="mt-8 bg-gradient-to-r from-green-50 to-blue-50 rounded-xl border-2 border-green-300 p-6">
+          <div className="mt-8 bg-gradient-to-r from-green-50 to-brand-50 rounded-xl border-2 border-green-300 p-6">
             <div className="text-center">
               <div className="text-3xl mb-3">💰</div>
               <h3 className="text-xl font-bold text-gray-900 mb-3">
@@ -399,7 +399,7 @@ export default function SimuladorIRSPage() {
                 className={`bg-white rounded-xl shadow-lg p-6 border-2 transition ${
                   scenario === bestScenario
                     ? "border-green-400 shadow-green-100"
-                    : "border-gray-200 hover:border-blue-300"
+                    : "border-gray-200 hover:border-brand-300"
                 }`}
               >
                 <div className="flex items-center justify-between mb-4">
@@ -412,7 +412,7 @@ export default function SimuladorIRSPage() {
                     </span>
                   )}
                   {scenario === bestScenario && (
-                    <span className="px-2 py-1 bg-blue-100 text-blue-800 text-xs font-medium rounded-full">
+                    <span className="px-2 py-1 bg-brand-100 text-brand-800 text-xs font-medium rounded-full">
                       Recomendado
                     </span>
                   )}
@@ -465,14 +465,14 @@ export default function SimuladorIRSPage() {
         </div>
 
         {/* 2026 Changes Highlight */}
-        <div className="mt-8 bg-blue-50 border border-blue-200 rounded-xl p-6">
-          <h3 className="text-xl font-bold text-blue-900 mb-4">
+        <div className="mt-8 bg-brand-50 border border-brand-200 rounded-xl p-6">
+          <h3 className="text-xl font-bold text-brand-900 mb-4">
             📋 Mudanças Fiscais de 2026 para Arrendamento
           </h3>
           <div className="grid md:grid-cols-2 gap-6">
             <div>
-              <h4 className="font-semibold text-blue-800 mb-2">Novas Vantagens</h4>
-              <ul className="text-sm text-blue-700 space-y-2">
+              <h4 className="font-semibold text-brand-800 mb-2">Novas Vantagens</h4>
+              <ul className="text-sm text-brand-700 space-y-2">
                 <li>✅ Taxa reduzida de 10% para rendas até €2.300/mês</li>
                 <li>✅ Aplicável a contratos novos e existentes</li>
                 <li>✅ Válido de 2026 a 2029 (4 anos)</li>
@@ -480,8 +480,8 @@ export default function SimuladorIRSPage() {
               </ul>
             </div>
             <div>
-              <h4 className="font-semibold text-blue-800 mb-2">Como Aplicar</h4>
-              <ul className="text-sm text-blue-700 space-y-2">
+              <h4 className="font-semibold text-brand-800 mb-2">Como Aplicar</h4>
+              <ul className="text-sm text-brand-700 space-y-2">
                 <li>📝 Opção automática na declaração IRS 2027</li>
                 <li>📝 Sem necessidade de procedimentos especiais</li>
                 <li>📝 Aplica-se ao rendimento de 2026 em diante</li>
@@ -525,7 +525,7 @@ export default function SimuladorIRSPage() {
         </div>
 
         {/* CTA to waitlist */}
-        <div className="mt-8 bg-blue-600 text-white rounded-xl p-6 text-center">
+        <div className="mt-8 bg-brand-600 text-white rounded-xl p-6 text-center">
           <h3 className="text-xl font-bold mb-2">
             Quer gerir as suas propriedades profissionalmente?
           </h3>
@@ -535,7 +535,7 @@ export default function SimuladorIRSPage() {
           </p>
           <Link
             href="/"
-            className="inline-block px-8 py-3 bg-white text-blue-600 rounded-lg font-medium hover:bg-gray-50 transition"
+            className="inline-block px-8 py-3 bg-white text-brand-600 rounded-lg font-medium hover:bg-gray-50 transition"
           >
             Juntar à Lista de Espera
           </Link>

--- a/src/app/survey/page.tsx
+++ b/src/app/survey/page.tsx
@@ -123,7 +123,7 @@ export default function WaitlistSurveyPage() {
 
   if (step === 'success') {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-gradient-to-br from-brand-50 via-white to-brand-50 flex items-center justify-center p-4">
         <div className="max-w-2xl mx-auto">
           <div className="bg-white rounded-2xl shadow-xl p-8 text-center">
             <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
@@ -141,9 +141,9 @@ export default function WaitlistSurveyPage() {
               exatamente o que os senhorios portugueses precisam.
             </p>
 
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-8">
-              <h2 className="font-semibold text-blue-900 mb-3">O que acontece agora?</h2>
-              <ul className="text-blue-800 text-sm space-y-2 text-left">
+            <div className="bg-brand-50 border border-brand-200 rounded-lg p-6 mb-8">
+              <h2 className="font-semibold text-brand-900 mb-3">O que acontece agora?</h2>
+              <ul className="text-brand-800 text-sm space-y-2 text-left">
                 <li>• Vamos analisar todas as respostas do survey</li>
                 <li>• Ajustaremos o produto com base no vosso feedback</li>
                 <li>• Assim que estivermos prontos, contatamos-lhe primeiro</li>
@@ -154,13 +154,13 @@ export default function WaitlistSurveyPage() {
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link
                 href="/"
-                className="px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition"
+                className="px-6 py-3 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 transition"
               >
                 Voltar ao Site
               </Link>
               <Link
                 href="/calculadora"
-                className="px-6 py-3 border border-blue-300 text-blue-700 rounded-lg font-medium hover:bg-blue-50 transition"
+                className="px-6 py-3 border border-brand-300 text-brand-700 rounded-lg font-medium hover:bg-brand-50 transition"
               >
                 Usar Simulador Grátis
               </Link>
@@ -172,12 +172,12 @@ export default function WaitlistSurveyPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50 py-12 px-4">
+    <div className="min-h-screen bg-gradient-to-br from-brand-50 via-white to-brand-50 py-12 px-4">
       <div className="max-w-2xl mx-auto">
         {/* Header */}
         <div className="text-center mb-8">
           <Link href="/" className="inline-flex items-center space-x-2 mb-6">
-            <div className="w-8 h-8 bg-blue-600 rounded-lg"></div>
+            <div className="w-8 h-8 bg-brand-600 rounded-lg"></div>
             <span className="text-xl font-bold text-gray-900">Senhorio</span>
           </Link>
 
@@ -203,7 +203,7 @@ export default function WaitlistSurveyPage() {
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="o-seu-email@exemplo.com"
                   required
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
                 <p className="text-sm text-gray-500 mt-1">
                   Usaremos isto para confirmar que está na nossa lista de espera
@@ -219,7 +219,7 @@ export default function WaitlistSurveyPage() {
               <button
                 type="submit"
                 disabled={loading || !email}
-                className="w-full px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                className="w-full px-6 py-3 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition"
               >
                 {loading ? "A verificar..." : "Continuar"}
               </button>
@@ -239,7 +239,7 @@ export default function WaitlistSurveyPage() {
                 <div className="space-y-3">
                   {[
                     { value: 'definitely', label: 'Definitivamente pagaria', color: 'bg-green-100 border-green-300 text-green-800' },
-                    { value: 'probably', label: 'Provavelmente pagaria', color: 'bg-blue-100 border-blue-300 text-blue-800' },
+                    { value: 'probably', label: 'Provavelmente pagaria', color: 'bg-brand-100 border-brand-300 text-brand-800' },
                     { value: 'maybe', label: 'Talvez pagaria', color: 'bg-yellow-100 border-yellow-300 text-yellow-800' },
                     { value: 'probably_not', label: 'Provavelmente não pagaria', color: 'bg-orange-100 border-orange-300 text-orange-800' },
                     { value: 'definitely_not', label: 'Definitivamente não pagaria', color: 'bg-red-100 border-red-300 text-red-800' }
@@ -279,7 +279,7 @@ export default function WaitlistSurveyPage() {
                       placeholder="15"
                       value={surveyData.max_monthly_price}
                       onChange={(e) => setSurveyData(prev => ({ ...prev, max_monthly_price: e.target.value }))}
-                      className="w-24 px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-24 px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600"
                     />
                     <span className="text-gray-700">por mês</span>
                   </div>
@@ -303,7 +303,7 @@ export default function WaitlistSurveyPage() {
                         onChange={() => handleFeatureToggle(feature)}
                         className="mr-3"
                       />
-                      <span className={`px-3 py-2 rounded-lg border flex-1 text-sm ${surveyData.most_valuable_features.includes(feature) ? 'bg-blue-100 border-blue-300 text-blue-800' : 'bg-gray-50 border-gray-200 text-gray-700'} transition`}>
+                      <span className={`px-3 py-2 rounded-lg border flex-1 text-sm ${surveyData.most_valuable_features.includes(feature) ? 'bg-brand-100 border-brand-300 text-brand-800' : 'bg-gray-50 border-gray-200 text-gray-700'} transition`}>
                         {feature}
                       </span>
                     </label>
@@ -324,7 +324,7 @@ export default function WaitlistSurveyPage() {
                   value={surveyData.current_solution}
                   onChange={(e) => setSurveyData(prev => ({ ...prev, current_solution: e.target.value }))}
                   rows={3}
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600"
                 />
               </div>
 
@@ -341,7 +341,7 @@ export default function WaitlistSurveyPage() {
                   value={surveyData.feedback}
                   onChange={(e) => setSurveyData(prev => ({ ...prev, feedback: e.target.value }))}
                   rows={4}
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600"
                 />
               </div>
 
@@ -354,7 +354,7 @@ export default function WaitlistSurveyPage() {
               <button
                 type="submit"
                 disabled={loading || !surveyData.willingness_to_pay}
-                className="w-full px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                className="w-full px-6 py-3 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition"
               >
                 {loading ? "A guardar respostas..." : "Enviar Respostas"}
               </button>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -20,7 +20,7 @@ export default function TermsPage() {
       {/* Header */}
       <header className="border-b border-gray-200">
         <div className="max-w-4xl mx-auto px-6 py-6">
-          <Link href="/" className="text-sm text-blue-600 hover:text-blue-700 transition">
+          <Link href="/" className="text-sm text-brand-600 hover:text-brand-700 transition">
             ← Voltar ao Senhorio
           </Link>
           <h1 className="text-3xl font-bold text-gray-900 mt-4">
@@ -226,9 +226,9 @@ export default function TermsPage() {
           </div>
         </section>
 
-        <section className="bg-blue-50 border border-blue-200 rounded-lg p-6 mt-12">
-          <h3 className="text-lg font-semibold text-blue-900 mb-2">Sobre o Desenvolvimento do Senhorio</h3>
-          <p className="text-blue-800 text-sm">
+        <section className="bg-brand-50 border border-brand-200 rounded-lg p-6 mt-12">
+          <h3 className="text-lg font-semibold text-brand-900 mb-2">Sobre o Desenvolvimento do Senhorio</h3>
+          <p className="text-brand-800 text-sm">
             O Senhorio está em desenvolvimento ativo. Estes Termos aplicam-se à versão atual
             e serão atualizados conforme novas funcionalidades são lançadas. Utilizadores da
             lista de espera serão notificados de mudanças significativas nos termos de serviço.

--- a/src/components/PaymentIntentModal.tsx
+++ b/src/components/PaymentIntentModal.tsx
@@ -122,7 +122,7 @@ export default function PaymentIntentModal({ isOpen, onClose, selectedPlan }: Pa
             </p>
             <button
               onClick={onClose}
-              className="w-full bg-blue-600 text-white py-3 rounded-lg font-medium hover:bg-blue-700 transition"
+              className="w-full bg-brand-600 text-white py-3 rounded-lg font-medium hover:bg-brand-700 transition"
             >
               Continuar
             </button>
@@ -131,8 +131,8 @@ export default function PaymentIntentModal({ isOpen, onClose, selectedPlan }: Pa
           /* Form State */
           <>
             <div className="mb-6">
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-                <p className="text-blue-800 text-sm">
+              <div className="bg-brand-50 border border-brand-200 rounded-lg p-4">
+                <p className="text-brand-800 text-sm">
                   <strong>🚀 Lançamento em breve!</strong>
                   <br />
                   O Senhorio está quase pronto. Registe o seu interesse e será um dos primeiros a ter acesso.
@@ -151,7 +151,7 @@ export default function PaymentIntentModal({ isOpen, onClose, selectedPlan }: Pa
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="o-seu-email@exemplo.com"
                   required
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -164,7 +164,7 @@ export default function PaymentIntentModal({ isOpen, onClose, selectedPlan }: Pa
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   placeholder="O seu nome"
-                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent"
                 />
               </div>
 
@@ -185,7 +185,7 @@ export default function PaymentIntentModal({ isOpen, onClose, selectedPlan }: Pa
                 <button
                   type="submit"
                   disabled={state === "loading" || !email}
-                  className="flex-1 px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                  className="flex-1 px-6 py-3 bg-brand-600 text-white rounded-lg font-medium hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-600 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition"
                 >
                   {state === "loading" ? "A registar..." : "Registar Interesse"}
                 </button>

--- a/src/components/PricingABTest.tsx
+++ b/src/components/PricingABTest.tsx
@@ -210,9 +210,9 @@ export default function PricingABTest({ onPricingClick }: PricingABTestProps) {
 
         <div className="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
           {variant.plans.map((plan, i) => (
-            <div key={i} className={`bg-white rounded-2xl shadow-lg p-8 relative ${plan.popular ? 'ring-2 ring-blue-500 scale-105' : ''}`}>
+            <div key={i} className={`bg-white rounded-2xl shadow-lg p-8 relative ${plan.popular ? 'ring-2 ring-brand-600 scale-105' : ''}`}>
               {plan.popular && (
-                <div className="absolute -top-4 left-1/2 transform -translate-x-1/2 bg-blue-500 text-white px-6 py-2 rounded-full text-sm font-semibold">
+                <div className="absolute -top-4 left-1/2 transform -translate-x-1/2 bg-brand-500 text-white px-6 py-2 rounded-full text-sm font-semibold">
                   Mais Popular
                 </div>
               )}
@@ -237,7 +237,7 @@ export default function PricingABTest({ onPricingClick }: PricingABTestProps) {
 
               <button
                 onClick={() => handlePlanClick(plan)}
-                className={`w-full px-6 py-3 rounded-xl font-semibold transition text-center ${plan.popular ? 'bg-blue-600 text-white hover:bg-blue-700' : 'border border-gray-300 text-gray-700 hover:bg-gray-50'}`}
+                className={`w-full px-6 py-3 rounded-xl font-semibold transition text-center ${plan.popular ? 'bg-brand-600 text-white hover:bg-brand-700' : 'border border-gray-300 text-gray-700 hover:bg-gray-50'}`}
               >
                 {plan.cta}
               </button>


### PR DESCRIPTION
## Summary

- Propagates the teal `brand-*` color scale (defined in `globals.css @theme` via PR #61) to every file in the repo
- Replaces all `blue-*` and `indigo-*` Tailwind classes with `brand-*` equivalents
- 37 files changed — no functional changes, zero blue-* remaining outside `/admin`

## Files changed

- **14 blog article pages** — nav badges, CTA sections, highlight boxes, gradient banners
- **Interactive tools** — `/calculadora`, `/simulador-irs`, `/calculadora-rendas`, `/recibos`
- **Auth pages** — `/login`, `/register`
- **Dashboard** — layout nav, properties, receipts, tax-reports
- **Components** — `PricingABTest`, `PaymentIntentModal`, `IrsAnnouncementBanner`
- **Legal pages** — privacy, terms, cookies

## Test plan

- [ ] Homepage → teal throughout ✓ (PR #61)
- [ ] `/calculadora` — teal selector buttons, CTA
- [ ] `/recibos` — teal submit button
- [ ] `/blog/*` — teal article badges and CTA banners
- [ ] `/login`, `/register` — teal form focus rings and submit button
- [ ] Vercel preview build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)